### PR TITLE
feat: add test infrastructure for persona.sh and comms protocol

### DIFF
--- a/tests/claude
+++ b/tests/claude
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Mock Claude CLI binary for testing.
+# Drop tests/ into PATH before real claude to intercept calls.
+#
+# Environment controls:
+#   MOCK_CLAUDE_COST    Cost to report in JSON output (default: 0.01)
+#   MOCK_CLAUDE_DELAY   Sleep N seconds before responding (timeout tests)
+#   MOCK_CLAUDE_EXIT    Exit code to return (default: 0) — exits before output
+#   MOCK_CLAUDE_OUTPUT  Persona text for --output-format json responses
+
+[ -n "${MOCK_CLAUDE_DELAY:-}" ] && sleep "$MOCK_CLAUDE_DELAY"
+
+# Non-zero exit — bail before producing any output (simulates API/network error)
+if [ "${MOCK_CLAUDE_EXIT:-0}" != "0" ]; then
+  exit "$MOCK_CLAUDE_EXIT"
+fi
+
+# Parse --output-format from argv (ignore all other flags)
+OUTPUT_FORMAT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output-format) OUTPUT_FORMAT="${2:-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [ "$OUTPUT_FORMAT" = "json" ]; then
+  # persona.sh extracts via: jq -r '.result // empty'
+  python3 - <<'PY'
+import json, os
+content = os.environ.get(
+    'MOCK_CLAUDE_OUTPUT',
+    '# Owner Persona\n\n## Priorities\nShip fast\n\n'
+    '## Style\nClean bash\n\n## Avoid\nBreaking tests\n\n'
+    '## Current focus\nTest coverage'
+)
+cost = float(os.environ.get('MOCK_CLAUDE_COST', '0.01'))
+print(json.dumps({'result': content, 'cost_usd': cost}))
+PY
+else
+  # stream-json: loop.sh only checks whether HEAD moved, not output content
+  echo '{"type":"result","subtype":"success"}'
+fi

--- a/tests/test_comms.sh
+++ b/tests/test_comms.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Tests for the .autonomous/comms.json protocol.
+# Covers the exact python3 snippets embedded in master-poll.sh,
+# master-watch.sh, and the worker prompt in SKILL.md.
+# No mock claude needed — pure JSON state machine tests.
+
+set -euo pipefail
+
+# ── Minimal test framework ──────────────────────────────────────────────────
+PASS=0; FAIL=0
+
+ok()   { echo "  ok  $*"; ((PASS++)) || true; }
+fail() { echo "  FAIL $*"; ((FAIL++)) || true; }
+
+assert_eq() {
+  [ "$1" = "$2" ] && ok "$3" || fail "$3 — got '$1', want '$2'"
+}
+assert_contains() {
+  echo "$1" | grep -q "$2" && ok "$3" || fail "$3 — '$2' not in output"
+}
+
+# ── Temp dir management ─────────────────────────────────────────────────────
+TMPDIRS=()
+new_tmp() { local d; d=$(mktemp -d); TMPDIRS+=("$d"); echo "$d"; }
+cleanup() { [ ${#TMPDIRS[@]} -gt 0 ] && rm -rf "${TMPDIRS[@]}" || true; }
+trap cleanup EXIT
+
+# Helper: write comms.json to a dir
+write_comms() {
+  # $1 = dir, $2 = JSON string
+  mkdir -p "$1/.autonomous"
+  echo "$2" > "$1/.autonomous/comms.json"
+}
+
+# Helper: read status using the exact snippet from master-watch.sh
+read_status() {
+  # $1 = comms.json path
+  python3 -c "import json; print(json.load(open('$1')).get('status','?'))" 2>/dev/null || echo "?"
+}
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_comms.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# 1. Status detection — idle
+echo ""
+echo "1. Status detection"
+T=$(new_tmp)
+write_comms "$T" '{"status":"idle"}'
+assert_eq "$(read_status "$T/.autonomous/comms.json")" "idle" "reads idle"
+
+write_comms "$T" '{"status":"waiting"}'
+assert_eq "$(read_status "$T/.autonomous/comms.json")" "waiting" "reads waiting"
+
+write_comms "$T" '{"status":"answered"}'
+assert_eq "$(read_status "$T/.autonomous/comms.json")" "answered" "reads answered"
+
+# 2. Missing file or malformed JSON → returns "?"
+echo ""
+echo "2. Missing or malformed comms.json → returns '?'"
+T=$(new_tmp)
+STATUS=$(python3 -c "import json; print(json.load(open('$T/.autonomous/comms.json')).get('status','?'))" 2>/dev/null || echo "?")
+assert_eq "$STATUS" "?" "gracefully handles missing file"
+
+mkdir -p "$T/.autonomous"
+echo '{"status":' > "$T/.autonomous/comms.json"   # truncated / malformed
+assert_eq "$(read_status "$T/.autonomous/comms.json")" "?" "gracefully handles malformed JSON"
+
+# 3. Worker writes waiting format (exact format from SKILL.md)
+echo ""
+echo "3. Worker writes waiting format"
+T=$(new_tmp); mkdir -p "$T/.autonomous"
+python3 -c "
+import json
+json.dump({
+    'status': 'waiting',
+    'questions': [{
+        'question': 'Which approach should I use?',
+        'header': 'Architecture Decision',
+        'options': [{'label': 'Monolith'}, {'label': 'Microservices'}],
+        'multiSelect': False
+    }],
+    'rec': 'A'
+}, open('$T/.autonomous/comms.json', 'w'))
+"
+assert_eq "$(read_status "$T/.autonomous/comms.json")" "waiting" "status is waiting"
+
+# Validate structure with python3
+VALID=$(python3 -c "
+import json
+d = json.load(open('$T/.autonomous/comms.json'))
+q = d['questions'][0]
+assert d['status'] == 'waiting'
+assert isinstance(d['questions'], list)
+assert 'question' in q
+assert 'header' in q
+assert 'options' in q
+assert isinstance(q['multiSelect'], bool)
+assert 'rec' in d
+print('ok')
+" 2>/dev/null || echo "fail")
+assert_eq "$VALID" "ok" "waiting JSON has required fields"
+
+# 4. Master writes answered format
+echo ""
+echo "4. Master writes answered format"
+T=$(new_tmp); mkdir -p "$T/.autonomous"
+python3 -c "
+import json
+json.dump({'status': 'answered', 'answers': ['A']}, open('$T/.autonomous/comms.json', 'w'))
+"
+assert_eq "$(read_status "$T/.autonomous/comms.json")" "answered" "status is answered"
+VALID=$(python3 -c "
+import json
+d = json.load(open('$T/.autonomous/comms.json'))
+assert d['status'] == 'answered'
+assert isinstance(d['answers'], list)
+assert len(d['answers']) > 0
+print('ok')
+" 2>/dev/null || echo "fail")
+assert_eq "$VALID" "ok" "answered JSON has required fields"
+
+# 5. Full round trip: idle → waiting → answered → idle
+echo ""
+echo "5. Full round trip"
+T=$(new_tmp); mkdir -p "$T/.autonomous"
+COMMS="$T/.autonomous/comms.json"
+
+# Init
+echo '{"status":"idle"}' > "$COMMS"
+assert_eq "$(read_status "$COMMS")" "idle" "starts idle"
+
+# Worker asks
+python3 -c "
+import json
+json.dump({'status':'waiting','questions':[{'question':'Proceed?','header':'Confirm','options':[{'label':'Yes'},{'label':'No'}],'multiSelect':False}],'rec':'A'}, open('$COMMS','w'))
+"
+assert_eq "$(read_status "$COMMS")" "waiting" "worker sets waiting"
+
+# Master answers
+python3 -c "import json; json.dump({'status':'answered','answers':['A']}, open('$COMMS','w'))"
+assert_eq "$(read_status "$COMMS")" "answered" "master sets answered"
+
+# Worker reads answer and resets
+ANSWER=$(python3 -c "
+import json
+d = json.load(open('$COMMS'))
+if d.get('status') == 'answered':
+    for a in d.get('answers', []): print(a)
+" 2>/dev/null)
+assert_eq "$ANSWER" "A" "worker reads correct answer"
+
+# Reset to idle
+echo '{"status":"idle"}' > "$COMMS"
+assert_eq "$(read_status "$COMMS")" "idle" "resets to idle"
+
+# 6. Question display (exact snippet from master-poll.sh)
+echo ""
+echo "6. Question display rendering"
+T=$(new_tmp); mkdir -p "$T/.autonomous"
+COMMS="$T/.autonomous/comms.json"
+python3 -c "
+import json
+json.dump({
+    'status': 'waiting',
+    'questions': [{
+        'question': 'Pick a deployment strategy',
+        'header': 'Deploy',
+        'options': [{'label': 'Blue-green'}, {'label': 'Rolling'}],
+        'multiSelect': False
+    }],
+    'rec': 'B'
+}, open('$COMMS', 'w'))
+"
+
+DISPLAY=$(python3 << PYEOF
+import json
+d = json.load(open('$COMMS'))
+for q in d.get('questions', []):
+    print(f"  [{q.get('header','')}]")
+    print(f"  {q['question'][:500]}")
+    print()
+    for i, o in enumerate(q.get('options', [])):
+        label = o['label'] if isinstance(o, dict) else o
+        print(f"    {chr(65+i)}) {label}")
+print(f"\n  rec: {d.get('rec','—')}")
+PYEOF
+)
+assert_contains "$DISPLAY" "[Deploy]"                   "header rendered"
+assert_contains "$DISPLAY" "Pick a deployment strategy" "question text rendered"
+assert_contains "$DISPLAY" "A) Blue-green"              "first option is A"
+assert_contains "$DISPLAY" "B) Rolling"                 "second option is B"
+assert_contains "$DISPLAY" "rec: B"                     "recommendation shown"
+
+# 7. Question display handles plain string options (not dicts)
+echo ""
+echo "7. Display handles plain string options"
+T=$(new_tmp); mkdir -p "$T/.autonomous"
+COMMS="$T/.autonomous/comms.json"
+python3 -c "
+import json
+json.dump({
+    'status': 'waiting',
+    'questions': [{'question': 'Choose','header': 'H','options': ['Alpha','Beta'],'multiSelect': False}],
+    'rec': 'A'
+}, open('$COMMS', 'w'))
+"
+DISPLAY=$(python3 << PYEOF
+import json
+d = json.load(open('$COMMS'))
+for q in d.get('questions', []):
+    for i, o in enumerate(q.get('options', [])):
+        label = o['label'] if isinstance(o, dict) else o
+        print(f"    {chr(65+i)}) {label}")
+PYEOF
+)
+assert_contains "$DISPLAY" "A) Alpha" "plain string option A rendered"
+assert_contains "$DISPLAY" "B) Beta"  "plain string option B rendered"
+
+# 8. multiSelect flag round-trips correctly
+echo ""
+echo "8. multiSelect flag"
+T=$(new_tmp); mkdir -p "$T/.autonomous"
+COMMS="$T/.autonomous/comms.json"
+python3 -c "
+import json
+json.dump({'status':'waiting','questions':[{'question':'Pick all that apply','header':'Multi','options':[{'label':'A1'},{'label':'A2'}],'multiSelect':True}],'rec':'A'}, open('$COMMS','w'))
+"
+MS=$(python3 -c "import json; print(json.load(open('$COMMS'))['questions'][0]['multiSelect'])")
+assert_eq "$MS" "True" "multiSelect=True preserved"
+
+# 9. Multiple questions in one batch
+echo ""
+echo "9. Multiple questions in one batch"
+T=$(new_tmp); mkdir -p "$T/.autonomous"
+COMMS="$T/.autonomous/comms.json"
+python3 -c "
+import json
+json.dump({
+    'status': 'waiting',
+    'questions': [
+        {'question': 'Q1','header': 'H1','options': [{'label':'Yes'}],'multiSelect': False},
+        {'question': 'Q2','header': 'H2','options': [{'label':'No'}],'multiSelect': False}
+    ],
+    'rec': 'A'
+}, open('$COMMS', 'w'))
+"
+COUNT=$(python3 -c "import json; print(len(json.load(open('$COMMS'))['questions']))")
+assert_eq "$COUNT" "2" "two questions stored"
+DISPLAY=$(python3 << PYEOF
+import json
+d = json.load(open('$COMMS'))
+for q in d.get('questions', []):
+    print(f"  [{q.get('header','')}]")
+PYEOF
+)
+assert_contains "$DISPLAY" "[H1]" "first question header rendered"
+assert_contains "$DISPLAY" "[H2]" "second question header rendered"
+
+# 10. Worker answer poll loop reads correctly on pre-answered state
+echo ""
+echo "10. Worker reads answered status immediately"
+T=$(new_tmp); mkdir -p "$T/.autonomous"
+COMMS="$T/.autonomous/comms.json"
+python3 -c "import json; json.dump({'status':'answered','answers':['B']}, open('$COMMS','w'))"
+
+ANSWER=$(python3 << PYEOF
+import json, time
+for _ in range(1):   # one iteration only (already answered)
+    d = json.load(open('$COMMS'))
+    if d.get('status') == 'answered':
+        for a in d.get('answers', []):
+            print(a)
+        break
+PYEOF
+)
+assert_eq "$ANSWER" "B" "worker reads answer B"
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Results: $PASS passed, $FAIL failed"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+[ "$FAIL" -eq 0 ]

--- a/tests/test_persona.sh
+++ b/tests/test_persona.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Tests for scripts/persona.sh
+# Uses tests/claude mock binary — no real API calls.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PERSONA_SH="$REPO_ROOT/scripts/persona.sh"
+
+# Intercept 'claude' with mock before real binary
+export PATH="$REPO_ROOT/tests:$PATH"
+
+# ── Minimal test framework ──────────────────────────────────────────────────
+PASS=0; FAIL=0
+
+ok()   { echo "  ok  $*"; ((PASS++)) || true; }
+fail() { echo "  FAIL $*"; ((FAIL++)) || true; }
+
+assert_eq() {
+  [ "$1" = "$2" ] && ok "$3" || fail "$3 — got '$1', want '$2'"
+}
+assert_file_exists() {
+  [ -f "$1" ] && ok "$2" || fail "$2 — file missing: $1"
+}
+assert_file_contains() {
+  grep -q "$2" "$1" 2>/dev/null && ok "$3" || fail "$3 — '$2' not in $1"
+}
+assert_file_not_contains() {
+  grep -q "$2" "$1" 2>/dev/null && fail "$3 — '$2' unexpectedly in $1" || ok "$3"
+}
+
+# ── Temp dir management ─────────────────────────────────────────────────────
+TMPDIRS=()
+new_tmp() { local d; d=$(mktemp -d); TMPDIRS+=("$d"); echo "$d"; }
+cleanup() { [ ${#TMPDIRS[@]} -gt 0 ] && rm -rf "${TMPDIRS[@]}" || true; }
+trap cleanup EXIT
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_persona.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# 1. OWNER.md already exists → return path, do not overwrite
+echo ""
+echo "1. OWNER.md already exists"
+T=$(new_tmp)
+echo "# Existing Persona" > "$T/OWNER.md"
+OUT=$(bash "$PERSONA_SH" "$T" 2>/dev/null)
+assert_eq "$OUT" "$T/OWNER.md" "returns existing path"
+assert_file_contains "$T/OWNER.md" "Existing Persona" "does not overwrite existing content"
+
+# 2. No context (no git, no CLAUDE.md, no README) → copies template
+echo ""
+echo "2. No context → copies template"
+T=$(new_tmp)
+bash "$PERSONA_SH" "$T" >/dev/null 2>&1
+assert_file_exists "$T/OWNER.md" "OWNER.md created"
+assert_file_contains "$T/OWNER.md" "Priorities" "template content present"
+
+# 3. Has CLAUDE.md → invokes mock claude, writes generated persona
+echo ""
+echo "3. Has CLAUDE.md → claude generates persona"
+T=$(new_tmp)
+echo "# Project instructions" > "$T/CLAUDE.md"
+if command -v jq >/dev/null 2>&1; then
+  export MOCK_CLAUDE_OUTPUT="# Owner Persona
+
+## Priorities
+Ship fast
+
+## Style
+Clean bash
+
+## Avoid
+Breaking tests
+
+## Current focus
+Test coverage"
+  bash "$PERSONA_SH" "$T" >/dev/null 2>&1
+  unset MOCK_CLAUDE_OUTPUT
+  assert_file_exists "$T/OWNER.md" "OWNER.md created"
+  assert_file_contains "$T/OWNER.md" "Ship fast" "generated content written"
+else
+  echo "  skip (jq not installed)"
+fi
+
+# 4. Has git history → invokes mock claude, writes generated persona
+echo ""
+echo "4. Has git history → claude generates persona"
+T=$(new_tmp)
+git -C "$T" init -q
+git -C "$T" -c user.email="t@t.com" -c user.name="T" commit -m "init" --allow-empty -q
+if command -v jq >/dev/null 2>&1; then
+  export MOCK_CLAUDE_OUTPUT="# Owner Persona
+
+## Priorities
+Code quality
+
+## Style
+Typed, tested
+
+## Avoid
+Big rewrites
+
+## Current focus
+Refactor auth"
+  bash "$PERSONA_SH" "$T" >/dev/null 2>&1
+  unset MOCK_CLAUDE_OUTPUT
+  assert_file_exists "$T/OWNER.md" "OWNER.md created"
+  assert_file_contains "$T/OWNER.md" "Code quality" "git-history-based persona written"
+else
+  echo "  skip (jq not installed)"
+fi
+
+# 5. Has README.md → invokes mock claude, writes generated persona
+echo ""
+echo "5. Has README.md → claude generates persona"
+T=$(new_tmp)
+echo "# My Project" > "$T/README.md"
+if command -v jq >/dev/null 2>&1; then
+  export MOCK_CLAUDE_OUTPUT="# Owner Persona
+
+## Priorities
+User experience
+
+## Style
+Minimal
+
+## Avoid
+Over-engineering
+
+## Current focus
+Onboarding flow"
+  bash "$PERSONA_SH" "$T" >/dev/null 2>&1
+  unset MOCK_CLAUDE_OUTPUT
+  assert_file_exists "$T/OWNER.md" "OWNER.md created"
+  assert_file_contains "$T/OWNER.md" "User experience" "README-based persona written"
+else
+  echo "  skip (jq not installed)"
+fi
+
+# 6. Claude fails (MOCK_CLAUDE_EXIT=1) → falls back to template
+# MOCK_CLAUDE_OUTPUT is set to a sentinel so the not_contains assertion
+# actually tests something: if persona.sh mistakenly wrote generated
+# content despite failure, this string would appear in OWNER.md.
+echo ""
+echo "6. Claude fails → falls back to template"
+T=$(new_tmp)
+echo "# CLAUDE.md" > "$T/CLAUDE.md"
+export MOCK_CLAUDE_OUTPUT="FAIL_TEST_SENTINEL_SHOULD_NOT_APPEAR"
+export MOCK_CLAUDE_EXIT=1
+bash "$PERSONA_SH" "$T" >/dev/null 2>&1
+unset MOCK_CLAUDE_EXIT MOCK_CLAUDE_OUTPUT
+assert_file_exists "$T/OWNER.md" "OWNER.md still created"
+assert_file_contains "$T/OWNER.md" "Priorities" "template used as fallback"
+assert_file_not_contains "$T/OWNER.md" "FAIL_TEST_SENTINEL_SHOULD_NOT_APPEAR" "generated content not written on failure"
+
+# 7. Idempotent — second call does not regenerate
+echo ""
+echo "7. Idempotent — second call returns same file"
+T=$(new_tmp)
+echo "# Fixed Content" > "$T/OWNER.md"
+bash "$PERSONA_SH" "$T" >/dev/null 2>&1
+bash "$PERSONA_SH" "$T" >/dev/null 2>&1
+assert_file_contains "$T/OWNER.md" "Fixed Content" "content unchanged after second call"
+
+# 8. Default PROJECT_DIR is current directory
+echo ""
+echo "8. Default PROJECT_DIR is '.'"
+T=$(new_tmp)
+(cd "$T" && bash "$PERSONA_SH" >/dev/null 2>&1) || true
+assert_file_exists "$T/OWNER.md" "OWNER.md created in cwd"
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Results: $PASS passed, $FAIL failed"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+[ "$FAIL" -eq 0 ]

--- a/tests/timeout
+++ b/tests/timeout
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# macOS compatibility shim for GNU 'timeout' (not in macOS stock install).
+# If a real timeout binary exists in standard system paths, delegates to it.
+# This preserves timeout enforcement on Linux CI while making tests work on macOS.
+# Usage: timeout <seconds> <command> [args...]
+for _REAL in /usr/bin/timeout /usr/local/bin/timeout /opt/homebrew/bin/timeout /usr/local/opt/coreutils/libexec/gnubin/timeout; do
+  [ -x "$_REAL" ] && exec "$_REAL" "$@"
+done
+# No real timeout found (stock macOS) — drop the seconds arg and run directly.
+# NOTE: timeout behaviour is not tested on this platform.
+shift
+exec "$@"


### PR DESCRIPTION
## Summary

- `tests/claude`: mock Claude CLI binary, no real API calls (env: MOCK_CLAUDE_EXIT / MOCK_CLAUDE_DELAY / MOCK_CLAUDE_OUTPUT)
- `tests/timeout`: macOS shim, delegates to real timeout on Linux
- `tests/test_persona.sh`: 15 tests for scripts/persona.sh
- `tests/test_comms.sh`: 26 tests for .autonomous/comms.json state machine

41 tests, exit 0, no API calls required (python3 + jq only).

## How to run
bash tests/test_persona.sh && bash tests/test_comms.sh
