### PR TITLE
Clean stale sprint summaries on init and enhance testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ COMPETITIVE.md
 /tmp/
 *.jsonl
 /ref/**
+
+# Runtime state (per-session, never committed)
+.autonomous/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Cross-session persistent work queue in `.autonomous/backlog.json`:
 ## Testing
 
 ```bash
-bash tests/test_conductor.sh    # 87 tests: state management, phase transitions, exploration, input validation, CLI help
+bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
 bash tests/test_comms.sh        # 34 tests: comms.json protocol, master-watch/master-poll CLI help
 bash tests/test_persona.sh      # 20 tests: OWNER.md generation, CLI help
 bash tests/test_explore_scan.sh # 45 tests: 8-dimension scoring heuristics, edge cases, CLI help

--- a/scripts/conductor-state.sh
+++ b/scripts/conductor-state.sh
@@ -182,6 +182,9 @@ cmd_init() {
   [ "$max_sprints" -gt 0 ] || die "max-sprints must be > 0, got: $max_sprints"
 
   mkdir -p "$STATE_DIR"
+  # Clean stale sprint summaries from prior sessions
+  rm -f "$STATE_DIR/sprint-summary.json"
+  rm -f "$STATE_DIR"/sprint-*-summary.json
   acquire_lock
 
   local session_id="conductor-$(date +%s)"

--- a/tests/test_conductor.sh
+++ b/tests/test_conductor.sh
@@ -901,4 +901,50 @@ echo "44. --help exits 0"
 bash "$CONDUCTOR" --help >/dev/null 2>&1
 assert_eq "$?" "0" "--help exits with code 0"
 
+# ═══════════════════════════════════════════════════════════════════════════
+# 45. init cleans stale sprint-summary.json
+# ═══════════════════════════════════════════════════════════════════════════
+echo ""
+echo "45. init cleans stale sprint-summary.json"
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+echo '{"status":"complete","summary":"stale from prior session"}' > "$T/.autonomous/sprint-summary.json"
+echo '{"status":"complete","summary":"stale sprint 1"}' > "$T/.autonomous/sprint-1-summary.json"
+bash "$CONDUCTOR" init "$T" "fresh mission" 5 >/dev/null
+assert_file_not_exists "$T/.autonomous/sprint-summary.json" "stale sprint-summary.json removed"
+assert_file_not_exists "$T/.autonomous/sprint-1-summary.json" "stale sprint-1-summary.json removed"
+assert_file_exists "$T/.autonomous/conductor-state.json" "fresh conductor-state.json created"
+MISSION=$(python3 -c "import json; print(json.load(open('$T/.autonomous/conductor-state.json'))['mission'])")
+assert_eq "$MISSION" "fresh mission" "conductor-state has new mission"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 46. init preserves backlog.json
+# ═══════════════════════════════════════════════════════════════════════════
+echo ""
+echo "46. init preserves backlog.json"
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+echo '{"items":[{"title":"keep me"}]}' > "$T/.autonomous/backlog.json"
+echo '{"status":"complete"}' > "$T/.autonomous/sprint-summary.json"
+bash "$CONDUCTOR" init "$T" "new session" 5 >/dev/null
+assert_file_exists "$T/.autonomous/backlog.json" "backlog.json preserved"
+TITLE=$(python3 -c "import json; print(json.load(open('$T/.autonomous/backlog.json'))['items'][0]['title'])")
+assert_eq "$TITLE" "keep me" "backlog content intact"
+assert_file_not_exists "$T/.autonomous/sprint-summary.json" "stale summary cleaned"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 47. init cleans all numbered summaries
+# ═══════════════════════════════════════════════════════════════════════════
+echo ""
+echo "47. init cleans all numbered summaries"
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+for i in 1 2 3 4 5; do
+  echo "{\"status\":\"complete\",\"sprint\":$i}" > "$T/.autonomous/sprint-$i-summary.json"
+done
+bash "$CONDUCTOR" init "$T" "clean slate" 5 >/dev/null
+for i in 1 2 3 4 5; do
+  assert_file_not_exists "$T/.autonomous/sprint-$i-summary.json" "sprint-$i-summary.json removed"
+done
+
 print_results

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -35,6 +35,9 @@ assert_file_contains() {
 assert_file_not_contains() {
   grep -q "$2" "$1" 2>/dev/null && fail "$3 — '$2' unexpectedly in $1" || ok "$3"
 }
+assert_file_not_exists() {
+  [ ! -e "$1" ] && ok "$2" || fail "$2 — file exists: $1"
+}
 
 # ── Temp dir management ───────────────────────────────────────────────────────
 TMPDIRS=()


### PR DESCRIPTION
## Changes

- **conductor-state.sh**: Added cleanup of stale sprint summary files (`sprint-summary.json` and `sprint-*-summary.json`) in the `init` command to prevent carryover from prior sessions
- **test_conductor.sh**: Added 3 new test cases (45-47) covering stale summary cleanup, backlog preservation, and numbered summary removal
- **test_helpers.sh**: Added `assert_file_not_exists()` helper function for testing file absence
- **.gitignore**: Added `.autonomous/` directory (runtime state, never committed)
- **CLAUDE.md**: Updated test count from 87 to 99 tests with stale cleanup coverage

## Summary

Enhances init command to ensure clean session startup by removing stale artifacts while preserving the persistent backlog.