### PR TITLE
feat(coding-agent): Copilot Coding Agent variant with aggressive quality bar

### DIFF
--- a/coding-agent/AGENTS.md
+++ b/coding-agent/AGENTS.md
@@ -176,8 +176,33 @@ guessing. Example:
 ## Phase 3 — Final summary and ready-for-review
 
 Only after two consecutive clean rescans (every dimension ≥ 9, no new
-issues surfacing), update the PR description to the final form and mark
-the PR ready for review.
+issues surfacing) **and** every automated review thread is resolved,
+update the PR description to the final form and mark the PR ready for
+review.
+
+### Automated reviewer gate
+
+Before you mark the PR ready, every unresolved comment from automated
+PR reviewers must be handled. At time of writing the common ones are:
+
+- **GitHub Copilot** inline PR review
+- **CodeRabbit** (`coderabbitai[bot]`)
+- Any other bot that leaves pending review threads
+
+For each unresolved comment:
+
+1. If it is a legitimate issue → fix it, push a new commit, and reply
+   on the thread naming the commit SHA that addressed it.
+2. If it is wrong (false positive, out of scope, disagrees with a
+   deliberate choice) → reply explaining *why* you're not acting on
+   it, then resolve the thread.
+3. Never silently close a thread without a reply — reviewers (and the
+   human merging this PR) need to see your reasoning.
+
+If a thread blocks on information you don't have (production secrets,
+author intent on an ambiguous API), leave the PR in draft and note the
+blocker in **Validation gaps**. That is the only permitted reason to
+stay in draft once the scoreboard bar is met.
 
 If some dimensions are stuck below 9 after repeated attempts (marked
 "stuck" in Phase 2), the PR can still be marked ready, but the stop

--- a/coding-agent/AGENTS.md
+++ b/coding-agent/AGENTS.md
@@ -256,9 +256,32 @@ A reviewer should be able to trace the trajectory: which dimensions
 moved, which were rescored up or down between passes, and why.
 ```
 
-Then **mark the PR ready for review**. A draft PR is not a finished PR.
-If you stop in draft, the workflow has failed — the issue author has no
-signal that you're done.
+### Ship it — literal final action
+
+Marking the PR ready is a **concrete action**, not an attitude. Your
+last tool call in this workflow must be the shell command:
+
+```bash
+gh pr ready "$PR_NUMBER"
+```
+
+where `$PR_NUMBER` is this PR's number (available from the issue/PR
+context you started with, or `gh pr view --json number --jq .number`).
+
+Do **not** use words like "I've marked the PR ready" or "the PR is now
+ready" — those are narrative, not action. If you did not invoke
+`gh pr ready`, the PR is still draft and the workflow has failed.
+
+**Self-check before your session ends:**
+
+- [ ] PR description includes the Scoreboard, Files modified, Test
+  results, Validation gaps, Stop reason, and Passes sections defined
+  above (format matters — a prose summary is not a substitute)
+- [ ] `gh pr view --json isDraft --jq .isDraft` returns `false`
+- [ ] All automated reviewer threads resolved (see Automated reviewer
+  gate above)
+
+If any checkbox fails, you are not done. Loop back.
 
 ---
 

--- a/coding-agent/AGENTS.md
+++ b/coding-agent/AGENTS.md
@@ -1,0 +1,253 @@
+# Autonomous improvement workflow
+
+You are the **autonomous improvement agent** for this project. You scan the codebase,
+score it across 8 quality dimensions, fix the weakest, verify your work, rescan,
+fix again, and summarize — all yourself, driven by the issue that assigned you.
+
+There is **no user to ask questions**. Do not leave the PR in draft once you are
+finished. Your job ends when the PR is marked **ready for review**.
+
+### Quality bar — don't stop at "good enough"
+
+The target is **all 8 dimensions scoring ≥ 9** *and* two consecutive rescans
+finding no new gaps. A 7 is not a passing score; it is a sign the dimension
+needs another pass. Use every minute of your session budget — running
+unattended on cloud infra, leaving quality on the table is wasted compute.
+
+---
+
+## Phase 1 — Scan all dimensions
+
+Score these eight dimensions 0-10. **0** = absent or broken; **10** = thorough,
+idiomatic, well-tested. Use the heuristics column as a starting point — adjust
+based on what this project actually is (a CLI tool's "performance" looks very
+different from a web app's).
+
+| # | Dimension          | Heuristics to score by                                                                |
+|---|--------------------|---------------------------------------------------------------------------------------|
+| 1 | `test_coverage`    | Test files exist? Cover critical paths? Run? Pass? Match production code growth?      |
+| 2 | `error_handling`   | Errors caught at boundaries? Useful messages? Graceful degradation? No silent fails?  |
+| 3 | `security`         | Hardcoded secrets? Injection surface? Input validation at boundaries? Safe defaults?  |
+| 4 | `code_quality`     | Dead code? Duplication? Functions doing too much? Naming clarity?                     |
+| 5 | `documentation`    | README current? Public APIs documented? Setup instructions runnable?                  |
+| 6 | `architecture`     | Module boundaries clear? Dependency direction sensible? Separation of concerns?       |
+| 7 | `performance`      | N+1 queries? Blocking I/O on hot paths? Obvious unnecessary allocations?              |
+| 8 | `dx`               | CLI help text? Error messages actionable? Setup steps work? Onboarding friction?      |
+
+### How to scan
+
+For each dimension:
+
+1. Search the repo for the heuristic patterns
+   (e.g. `test_coverage` → look for test directories and test files;
+    `security` → grep for `password`, `secret`, `api_key`, `eval(`, `exec(`).
+2. Read a representative sample — don't read the whole codebase, just enough
+   to ground an honest score.
+3. Assign a 0-10 integer. Be honest. Inflated scores defeat the loop.
+
+### Write the initial scoreboard to the PR description
+
+Once all eight are scored, update the PR description with an **Initial
+scoreboard** section:
+
+```markdown
+## Initial scoreboard
+
+| Dimension       | Score | Evidence |
+|-----------------|-------|----------|
+| test_coverage   | 3     | Only 2 test files for 47 source files, no CI runner |
+| error_handling  | 5     | try/except at CLI boundary, but none in data layer   |
+| ...             | ...   | ... |
+```
+
+The PR description is your only persistent state — there is no `memory` tool
+and no `manage_todo_list`. Update the PR body after every dimension change.
+
+---
+
+## Phase 2 — Multi-pass fix loop
+
+You run **multiple passes**. Each pass fixes every dimension below 9. After
+each pass, rescore **all eight dimensions** (including the ones you already
+fixed — earlier fixes can reveal or create new issues). Stop only when two
+consecutive rescans find no dimension below 9.
+
+```
+pass = 1
+consecutive_clean_rescans = 0
+
+while consecutive_clean_rescans < 2:
+  # A full pass over every weak dimension
+  for dim in dimensions sorted by current score ascending:
+    if dim.score >= 9:
+      continue
+    files     = at most 5 files to touch for this fix
+    for each file in files:
+      read file end-to-end before editing
+      edit
+    run the project's test/lint commands (if any exist)
+    rescore   = honest 0-10 after the fix (be harsh on yourself)
+    append to the PR description under "Pass <N>":
+      `[<dimension>] <before> → <after> (<one-line summary>)`
+    if rescore <= before:
+      dim.consecutive_no_improvement += 1
+    else:
+      dim.consecutive_no_improvement = 0
+    if dim.consecutive_no_improvement >= 2:
+      mark dim as "stuck" and move on — don't keep spinning on it
+
+  # End-of-pass rescan of ALL dimensions, not just the ones touched
+  rescan all 8 dimensions with fresh eyes
+  if every dimension >= 9 and no new issues surfaced:
+    consecutive_clean_rescans += 1
+  else:
+    consecutive_clean_rescans = 0
+    pass += 1
+```
+
+### What "rescore" means in this workflow
+
+A rescore is **not** "did I do the work I planned?" — it is "looking at the
+codebase fresh, what score does this dimension honestly deserve?" A fix that
+adds one test for one function does not move `test_coverage` from 3 to 9;
+it moves it to maybe 5. Keep the bar high on yourself.
+
+On each rescore, ask:
+
+- Would a senior engineer reviewing this codebase give this dimension a 9?
+- Is there a blindingly obvious next issue I haven't addressed yet?
+- Did my fix introduce regressions elsewhere?
+
+If any answer is no / yes / yes, the dimension isn't done.
+
+### Per-dimension fix discipline
+
+- **Read before edit.** Never edit a file you haven't read end-to-end first.
+- **Match existing style.** If the project uses tabs, you use tabs. If
+  functions are snake_case, your new function is snake_case. Read neighbors
+  first.
+- **Smallest fix that moves the score.** A `test_coverage` 3→6 by adding one
+  test file for the most critical untested function beats 3→9 by
+  autogenerating brittle coverage for everything.
+- **Boundary not breadth.** If a dimension needs more than 5 files, take the
+  highest-leverage 5 and accept a partial score improvement. Add the rest as
+  a bullet in the PR description's **Deferred follow-ups** section.
+
+### Verification — non-negotiable
+
+After editing files for a dimension:
+
+1. Run the project's test command. Detect it from `package.json` scripts,
+   `Makefile` targets, `pyproject.toml`, `tox.ini`, or `*.sh` test runners —
+   don't invent one.
+2. If the repo has a CI matrix (multiple OSes or runtimes in
+   `.github/workflows/*.yml`), your tests must be portable across every
+   matrix entry. Never write POSIX-shell-only test invocations
+   (`VAR=value cmd ...`) if Windows is in the matrix — use
+   `cross-env` or equivalent.
+3. If tests fail, the fix is **not done**. Investigate, fix, re-run. If you
+   can't make them pass within reasonable effort, revert your changes for
+   that dimension and rescore at the original number — don't ship broken
+   work.
+
+### What you can't verify
+
+You run on a GitHub Linux runner. You can't observe:
+
+- The repo author's local OS, shell, or toolchain
+- Production runtime quirks
+- Real traffic patterns or data shape
+
+If a dimension's fix depends on something you can't verify, document the
+gap in the PR description's **Validation gaps** section rather than
+guessing. Example:
+
+```markdown
+## Validation gaps
+
+- `test_coverage` fix was verified on `ubuntu-latest` only. Repo has no
+  CI matrix, so Windows/macOS behavior is unverified.
+- `performance` fix reduces N+1 queries in theory; I could not benchmark
+  against production-shape data.
+```
+
+---
+
+## Phase 3 — Final summary and ready-for-review
+
+Only after two consecutive clean rescans (every dimension ≥ 9, no new
+issues surfacing), update the PR description to the final form and mark
+the PR ready for review.
+
+If some dimensions are stuck below 9 after repeated attempts (marked
+"stuck" in Phase 2), the PR can still be marked ready, but the stop
+reason must name them and the Validation gaps section must explain
+what's blocking the fix. "I ran out of time" is not a valid stop reason
+on cloud infra — either the fix exceeded the 5-files-per-dimension
+budget (deferred) or you hit a real blocker (document it).
+
+```markdown
+## Summary
+
+<1-2 sentence overview of what changed>
+
+## Scoreboard — before vs after
+
+| Dimension       | Before | After | Δ    | Files touched | Passes |
+|-----------------|--------|-------|------|---------------|--------|
+| test_coverage   | 3      | 9     | +6   | 7             | 2      |
+| error_handling  | 5      | 9     | +4   | 4             | 2      |
+| security        | 8      | 9     | +1   | 1             | 1      |
+| ...             | ...    | ...   | ...  | ...           | ...    |
+
+## Files modified
+
+Flat list of every file touched, grouped by dimension.
+
+## Test results
+
+Output of the final test invocation (last 30 lines). If no test runner
+exists, say so explicitly: *"No test runner detected; verification relied
+on static checks only."*
+
+## Validation gaps
+
+(see Phase 2 — include anything you could not verify)
+
+## Deferred follow-ups
+
+(bullets for work that exceeded the 5-files-per-dimension budget)
+
+## Stop reason
+
+One of: *"All dimensions ≥ 9 across two consecutive clean rescans"*,
+*"Stuck on `<dim1>`, `<dim2>` — details in Validation gaps"*,
+*"Session budget exhausted after N passes — deferred work in follow-ups"*.
+
+## Passes
+
+Numbered log of what was worked on in each pass (Pass 1, Pass 2, …).
+A reviewer should be able to trace the trajectory: which dimensions
+moved, which were rescored up or down between passes, and why.
+```
+
+Then **mark the PR ready for review**. A draft PR is not a finished PR.
+If you stop in draft, the workflow has failed — the issue author has no
+signal that you're done.
+
+---
+
+## What this workflow does NOT do
+
+- **No CI/CD changes.** Don't touch `.github/workflows/` existing files
+  (unless the `dx` or `architecture` dimension specifically requires it and
+  you can verify the change is safe).
+- **No new abstractions for hypothetical futures.** A bug fix doesn't need
+  a new helper. A test doesn't need a custom framework. Minimal, idiomatic,
+  gone.
+- **No silent rewrites.** Every file touched appears in the Files modified
+  section. A reviewer must be able to audit every change from the PR
+  description alone.
+- **No questions to the issue author.** There is no user to answer. If a
+  decision is ambiguous, pick the conservative option and note it in
+  Validation gaps.

--- a/coding-agent/README.md
+++ b/coding-agent/README.md
@@ -1,0 +1,109 @@
+# coding-agent — Autonomous improvement via Copilot Coding Agent
+
+The same 8-dimension improvement workflow as `/autonomous` and `/quickdo`,
+delivered as an **unattended PR-drafting bot** driven by
+[GitHub Copilot Coding Agent](https://docs.github.com/en/copilot/concepts/coding-agent/about-coding-agent).
+
+Assign an issue to `@copilot`, wait ~15 minutes, get a ready-for-review PR
+with a before/after scoreboard, file-level change list, and test output.
+
+---
+
+## What's in this directory
+
+| File | Purpose | Where it ends up |
+|------|---------|------------------|
+| `AGENTS.md` | The complete workflow. Three phases: scan → fix loop → summary. | Repo root of your target project |
+| `templates/copilot-instructions.md` | Short entry-point that points the bot at `AGENTS.md` | `.github/copilot-instructions.md` in your target project |
+| `templates/workflows/scheduled-audit.yml` | Optional weekly cron that opens an audit issue | `.github/workflows/` in your target project |
+| `trigger.sh` | One-shot issue creator (`gh issue create --assignee Copilot`) | Run from inside your checkout |
+
+---
+
+## Install in a target repo
+
+From the root of the repo you want audited:
+
+```bash
+# 1. Copy the workflow doc into the repo root
+curl -sL https://raw.githubusercontent.com/Sma1lboy/autonomous-skill/main/coding-agent/AGENTS.md -o AGENTS.md
+
+# 2. Copy the Copilot entry-point
+mkdir -p .github
+curl -sL https://raw.githubusercontent.com/Sma1lboy/autonomous-skill/main/coding-agent/templates/copilot-instructions.md -o .github/copilot-instructions.md
+
+# 3. Commit
+git add AGENTS.md .github/copilot-instructions.md
+git commit -m "chore: enable autonomous-skill coding-agent workflow"
+git push
+```
+
+Then enable Copilot coding agent on the repo in **Settings → Copilot** if it
+isn't already.
+
+## Trigger a run
+
+```bash
+# One-shot (creates an issue assigned to Copilot)
+bash <(curl -sL https://raw.githubusercontent.com/Sma1lboy/autonomous-skill/main/coding-agent/trigger.sh)
+```
+
+Or manually: open an issue, assign `Copilot`, body `"Run the autonomous
+improvement workflow per AGENTS.md"`.
+
+## Optional: scheduled audits
+
+Copy `templates/workflows/scheduled-audit.yml` to `.github/workflows/` to
+open a new audit issue every Sunday at 02:00 UTC.
+
+---
+
+## What to expect
+
+The bot runs in **multi-pass mode** with a high bar: the target is all 8
+dimensions scoring ≥ 9 *and* two consecutive rescans finding no new
+gaps — not a single soft pass at ≥ 7. It uses every minute of its
+session budget to squeeze quality out of the repo, rescoring honestly
+after each fix round.
+
+A draft PR opens within minutes of the issue being assigned. The bot
+works through multiple passes, and the PR flips to **ready for review**
+only once the quality bar is met. The PR description contains:
+
+- Initial scoreboard (all 8 dimensions, honest 0-10 scores)
+- Per-dimension fix summary (`[<dim>] <before> → <after>`)
+- Final before/after scoreboard
+- Flat list of files modified, grouped by dimension
+- Last 30 lines of test output
+- Validation gaps and deferred follow-ups
+
+If the PR stays in draft past ~30 minutes, the bot hit a two-strike halt or
+ran out of steam — check the PR description's **Stop reason** section.
+
+---
+
+## Compared to the Claude Code skills
+
+|                  | `/autonomous` (CC)                     | `/quickdo` (CC)         | coding-agent (this)          |
+|------------------|----------------------------------------|-------------------------|------------------------------|
+| Environment      | User's machine                         | User's machine          | GitHub Linux runner          |
+| Iteration model  | Conductor → Sprint Master → Worker     | One sprint              | One pass, 8 dimensions       |
+| Interactive      | Yes (discovery phase, comms.json)      | Yes (one question)      | No — fully unattended        |
+| Output           | `auto/session-*` branch on your machine | `auto/quickdo-*` branch | GitHub PR on the repo        |
+| Local env access | Full                                   | Full                    | None — Linux runner only     |
+| Quality bar      | Scores ≥ 7 per dimension               | Single focused fix      | Scores ≥ 9 + clean rescans   |
+| Typical runtime  | 30 min – several hours                 | 5 – 30 min              | ~30–60 min, multi-pass       |
+
+---
+
+## Limitations
+
+- **Linux runner only.** The bot can't observe your local OS, shell, toolchain,
+  or anything that isn't in the repo. If cross-platform matters, add a CI
+  matrix — `AGENTS.md` tells the bot to respect it.
+- **No persistent memory.** State lives in the PR description; every run
+  starts fresh.
+- **No follow-up questions.** Ambiguous decisions get the conservative
+  choice and are noted in **Validation gaps** in the PR description.
+- **Single pass.** This ships one PR per issue. For multi-sprint work with
+  phase transitions and exploration, use `/autonomous` from Claude Code.

--- a/coding-agent/templates/copilot-instructions.md
+++ b/coding-agent/templates/copilot-instructions.md
@@ -15,15 +15,21 @@ When an issue is assigned to you (`@copilot`):
    *and* two consecutive rescans finding no new gaps — not a softer ≥ 7
    single-pass target. Use every minute of session budget; stopping early
    with a 7 leaves quality on the table.
-5. **Never stop in draft.** Only after two clean rescans mark the PR
-   **ready for review**. A draft PR is not a finished PR — the issue
-   author has no signal that you're done. If some dimensions are stuck
-   below 9 after repeated attempts, still mark ready but document the
-   blocker in **Validation gaps**.
-5. **Document what you could not verify.** You run on a Linux runner and
-   cannot observe the author's local OS, production traffic, or real
-   data shape. Call out validation gaps in the PR description rather
-   than pretending you verified something you didn't.
+5. **Resolve every automated review thread before marking ready.**
+   GitHub Copilot inline review, CodeRabbit, and any other bot that
+   comments on the PR must have every thread resolved — either fix the
+   issue and reply with the commit SHA, or reply explaining why you're
+   not acting on it. Never silently close a thread.
+6. **Never stop in draft.** Only after two clean rescans *and* all
+   review threads resolved mark the PR **ready for review**. A draft
+   PR is not a finished PR — the issue author has no signal that
+   you're done. If some dimensions are stuck below 9 after repeated
+   attempts, still mark ready but document the blocker in **Validation
+   gaps**.
+7. **Document what you could not verify.** You run on a Linux runner
+   and cannot observe the author's local OS, production traffic, or
+   real data shape. Call out validation gaps in the PR description
+   rather than pretending you verified something you didn't.
 
 Refer to `AGENTS.md` for full scoring heuristics, fix-loop discipline,
 and the final summary template.

--- a/coding-agent/templates/copilot-instructions.md
+++ b/coding-agent/templates/copilot-instructions.md
@@ -1,0 +1,29 @@
+# Copilot Coding Agent instructions
+
+This repository uses the **autonomous improvement** pattern from
+[autonomous-skill](https://github.com/Sma1lboy/autonomous-skill).
+
+When an issue is assigned to you (`@copilot`):
+
+1. **Read `AGENTS.md` in the repo root first.** It contains the complete
+   workflow — three phases: scan, fix loop, summary.
+2. **There is no user.** Do not ask questions. Do not wait for follow-ups.
+   Proceed with the full 8-dimension scan.
+3. **The PR description is your scoreboard.** Update it after every
+   dimension change so a reviewer can audit progress at any point.
+4. **Multi-pass, high bar.** The target is all 8 dimensions scoring ≥ 9
+   *and* two consecutive rescans finding no new gaps — not a softer ≥ 7
+   single-pass target. Use every minute of session budget; stopping early
+   with a 7 leaves quality on the table.
+5. **Never stop in draft.** Only after two clean rescans mark the PR
+   **ready for review**. A draft PR is not a finished PR — the issue
+   author has no signal that you're done. If some dimensions are stuck
+   below 9 after repeated attempts, still mark ready but document the
+   blocker in **Validation gaps**.
+5. **Document what you could not verify.** You run on a Linux runner and
+   cannot observe the author's local OS, production traffic, or real
+   data shape. Call out validation gaps in the PR description rather
+   than pretending you verified something you didn't.
+
+Refer to `AGENTS.md` for full scoring heuristics, fix-loop discipline,
+and the final summary template.

--- a/coding-agent/templates/copilot-instructions.md
+++ b/coding-agent/templates/copilot-instructions.md
@@ -20,12 +20,17 @@ When an issue is assigned to you (`@copilot`):
    comments on the PR must have every thread resolved — either fix the
    issue and reply with the commit SHA, or reply explaining why you're
    not acting on it. Never silently close a thread.
-6. **Never stop in draft.** Only after two clean rescans *and* all
-   review threads resolved mark the PR **ready for review**. A draft
-   PR is not a finished PR — the issue author has no signal that
-   you're done. If some dimensions are stuck below 9 after repeated
-   attempts, still mark ready but document the blocker in **Validation
-   gaps**.
+6. **Never stop in draft.** Marking ready is a concrete action, not
+   an attitude. Your **last tool call** in this workflow must be:
+   ```bash
+   gh pr ready "$PR_NUMBER"
+   ```
+   Words like "I've marked the PR ready" are narrative, not action —
+   if you didn't actually run `gh pr ready`, the PR is still draft
+   and the workflow has failed. Before running it, confirm two clean
+   rescans *and* all review threads resolved. If some dimensions are
+   stuck below 9 after repeated attempts, still run `gh pr ready`
+   but document the blocker in **Validation gaps**.
 7. **Document what you could not verify.** You run on a Linux runner
    and cannot observe the author's local OS, production traffic, or
    real data shape. Call out validation gaps in the PR description

--- a/coding-agent/templates/workflows/scheduled-audit.yml
+++ b/coding-agent/templates/workflows/scheduled-audit.yml
@@ -1,0 +1,29 @@
+name: Scheduled autonomous audit
+
+# Creates a weekly audit issue assigned to Copilot. The bot reads AGENTS.md
+# and opens a draft PR with the 8-dimension improvement workflow.
+#
+# Copy to .github/workflows/scheduled-audit.yml in your repo to enable.
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'  # 02:00 UTC every Sunday
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  create-audit-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create audit issue assigned to Copilot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Weekly autonomous improvement audit" \
+            --body "Run the autonomous improvement workflow per \`AGENTS.md\`. Run multiple fix passes until every dimension scores ≥ 9 AND two consecutive rescans find no new gaps. Scoreboard goes in the PR description. Mark ready for review only when the bar is met." \
+            --assignee Copilot

--- a/coding-agent/trigger.sh
+++ b/coding-agent/trigger.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Create a GitHub issue assigned to Copilot that kicks off the
+# autonomous-skill coding-agent workflow in the current repository.
+#
+# Requires: gh CLI authenticated, run from inside a git checkout, and
+# Copilot coding agent enabled on the repo (Settings → Copilot).
+#
+# Env vars:
+#   REPO   — override the detected repo (owner/name). Default: auto-detect.
+#   TITLE  — issue title. Default: "Autonomous improvement audit".
+#   BODY   — issue body. Default: kicks off the AGENTS.md workflow.
+
+set -euo pipefail
+
+REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+TITLE="${TITLE:-Autonomous improvement audit}"
+BODY="${BODY:-Run the autonomous improvement workflow per \`AGENTS.md\`.
+
+Scan the project across all 8 quality dimensions. Run multiple fix passes until every dimension scores ≥ 9 AND two consecutive rescans find no new gaps. Update this PR description with the before/after scoreboard after each pass. Mark the PR ready for review only once the bar is met — do not stop at "good enough".}"
+
+echo "Creating issue in $REPO..." >&2
+gh issue create \
+  --repo "$REPO" \
+  --title "$TITLE" \
+  --body "$BODY" \
+  --assignee Copilot


### PR DESCRIPTION
## Summary

Adds a new top-level `coding-agent/` directory that ships the autonomous-skill 8-dimension improvement workflow as an **unattended PR-drafting bot** driven by GitHub Copilot Coding Agent. Parallel to `/autonomous` and `/quickdo` but runs on cloud infra from an issue assignment rather than interactively from the CLI.

Sibling to PR #49 (Copilot Chat variant under `copilot/`). These two are the same workflow delivered on two different Copilot surfaces:

| | `/autonomous`, `/quickdo` (CC) | Chat skill (PR #49) | coding-agent (this) |
|-|-|-|-|
| Surface | Claude Code | VS Code Copilot Chat | Copilot Coding Agent (cloud) |
| Interactive | Yes | Yes | No — fully unattended |
| Output | Branches locally | Branches locally | GitHub PR |

## Contents

| File | Purpose |
|------|---------|
| `coding-agent/AGENTS.md` | Complete workflow (scan → multi-pass fix loop → summary). User copies to their repo root. |
| `coding-agent/templates/copilot-instructions.md` | Short entry-point pointing bot at AGENTS.md. User copies to `.github/`. |
| `coding-agent/templates/workflows/scheduled-audit.yml` | Optional weekly cron that opens an audit issue. |
| `coding-agent/trigger.sh` | One-shot `gh issue create --assignee Copilot`. |
| `coding-agent/README.md` | Install + trigger + comparison + limitations. |

## Quality bar — different from interactive skills

Unattended cloud runs have session budget to spare, so AGENTS.md targets **all 8 dimensions ≥ 9 plus two consecutive clean rescans**, not a single ≥ 7 pass. The workflow explicitly demands multi-pass iteration with honest rescoring, forbids stopping in draft, and requires scoreboard updates in the PR description after every pass.

## Design decisions

- **Why not under `copilot/`** — PR #49 nests Chat skill assets under `copilot/skills/`, but main recently restructured to top-level skill dirs (`autonomous/`, `quickdo/`, `explore-ralph-loop/`). `coding-agent/` follows the new pattern. Can be reorganized under a shared parent later if desired.
- **No SKILL.md frontmatter** — `coding-agent/` ships content users install into *their* repo; it's not a Claude Code slash command itself.
- **Cross-platform testing constraint baked in** — AGENTS.md forbids POSIX-only test invocations (`VAR=value cmd …`) when the target repo has Windows in its CI matrix. Closes the gap observed on the bare-spike validation run where tests passed on the Linux runner but failed on the author's Windows machine.
- **No `memory` / `manage_todo_list`** — these aren't in the Coding Agent toolset. State lives in the PR description, updated per pass.

## Validation

Live validation running against `PengyuChen01/querygenerator`:

- **Baseline (bare spike):** [PR #2](https://github.com/PengyuChen01/querygenerator/pull/2) — closed. Bot shipped 26/29 passing tests (3 Windows failures from POSIX-only shell invocations) and left the PR in draft without marking ready.
- **With AGENTS.md:** [PR #5](https://github.com/PengyuChen01/querygenerator/pull/5) — in progress at time of opening this PR. Bot is already following multi-pass structure (commits labeled `Pass 1+2: …`). Final comparison will be appended to this PR as a review comment once it completes.

## Test plan

- [ ] Review AGENTS.md for clarity and missing edge cases
- [ ] Confirm validation PR (#5 on querygenerator) scores ≥ 9 across all 8 dimensions
- [ ] Confirm validation PR tests pass on both ubuntu-latest and windows-latest
- [ ] Confirm PR flips draft → ready-for-review without manual nudging
- [ ] Verify install flow from the README works end-to-end on a fresh repo