### PR TITLE
feat: mid-session intercept queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to autonomous-skill are documented here.
 
+## [Unreleased]
+
+### Added
+- `scripts/intercept.py` — mid-session intercept queue. External terminals can run `intercept.py add <project> "directive"` or `intercept.py pause <project>` to steer a running session. Conductor consumes between sprints via `status` + `consume`.
+- `tests/test_intercept.sh` — 50 tests covering add/pause/consume/clear, session scoping, concurrency, corruption resilience, and input validation.
+- README section "Mid-session intercepts" documenting the external CLI workflow.
+
+### Changed
+- `autonomous/SKILL.md` Plan phase reads `intercept.py status`/`consume` alongside backlog state; pause items stop the loop for user input, directive items fold into the next sprint direction.
+
 ## [0.6.0] — 2026-04-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/conductor-state.py` — Conductor state management (atomic writes, PID lock, phase transitions)
 - `scripts/explore-scan.py` — Project scanner: scores 8 exploration dimensions via heuristics
 - `scripts/backlog.py` — Cross-session persistent backlog (progressive disclosure, mkdir locking, max 50 items)
+- `scripts/intercept.py` — User intercept queue: external CLI writes directives/pauses into `.autonomous/intercept.json`; conductor consumes between sprints (mkdir locking, session-scoped)
 - `scripts/persona.py` — OWNER.md auto-generation from git history + project docs
 - `scripts/loop.py` — Standalone launcher (outside CC's skill system)
 - `scripts/master-poll.py` — Manual master polling for comms.json
@@ -152,7 +153,7 @@ then set `{"template":"<name>"}` in `skill-config.json` (or the project override
 
 ## Testing
 
-329 tests across 7 suites, all pure bash:
+405 tests across 9 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -163,6 +164,7 @@ bash tests/test_loop.sh         # 20 tests: standalone launcher args, env vars, 
 bash tests/test_backlog.sh      # 76 tests: CRUD, progressive disclosure, pick, prune, overflow, concurrency, validation
 bash tests/test_build_sprint_prompt.sh  # 25 tests: template resolution, allow/block injection, fallback, path-traversal guard
 bash tests/test_eval_output.sh  # 35 tests: eval-safe output, shell quoting, tmux cleanup
+bash tests/test_intercept.sh    # 50 tests: add/pause/consume/clear, session scoping, concurrency, corruption, validation
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,30 @@ a test suite, a refactor.
 AUTONOMOUS_DIRECTION="fix auth bugs" python3 scripts/loop.py /path/to/project
 ```
 
+### Mid-session intercepts
+
+Once a session is running, any external terminal can queue directives or pause
+requests that the conductor picks up between sprints:
+
+```bash
+cd /path/to/project
+
+# Redirect the next sprint
+python3 ~/.claude/skills/autonomous-skill/scripts/intercept.py add . \
+  "use Lucia for auth, not NextAuth"
+
+# Stop and hand control back to you on the next sprint boundary
+python3 ~/.claude/skills/autonomous-skill/scripts/intercept.py pause . \
+  "I want to review the direction"
+
+# Peek at the queue / clear it
+python3 ~/.claude/skills/autonomous-skill/scripts/intercept.py status .
+python3 ~/.claude/skills/autonomous-skill/scripts/intercept.py clear .
+```
+
+Intercepts take effect on the next Plan step — worst-case latency is the
+remaining runtime of the current sprint (≤ `CC_TIMEOUT`, default 15 minutes).
+
 ---
 
 ## Architecture

--- a/autonomous/SKILL.md
+++ b/autonomous/SKILL.md
@@ -98,6 +98,32 @@ BACKLOG_FULL=$(python3 "$SCRIPT_DIR/scripts/backlog.py" list "$(pwd)" open 2>/de
 BACKLOG_STATS=$(python3 "$SCRIPT_DIR/scripts/backlog.py" stats "$(pwd)" 2>/dev/null || echo "")
 ```
 
+**Between sprints — User intercepts:** Check whether the user (or any external
+actor) has queued intercepts since the last sprint. This is how the user
+steers the session mid-flight from another terminal:
+
+```bash
+INTERCEPT_STATUS=$(python3 "$SCRIPT_DIR/scripts/intercept.py" status "$(pwd)")
+if [ "$INTERCEPT_STATUS" != "none" ]; then
+  NEXT_SPRINT=$(python3 -c "import json; d=json.load(open('.autonomous/conductor-state.json')); print(len(d.get('sprints', []))+1)")
+  INTERCEPT_ITEMS=$(python3 "$SCRIPT_DIR/scripts/intercept.py" consume "$(pwd)" "$NEXT_SPRINT")
+  echo "$INTERCEPT_ITEMS"
+fi
+```
+
+Handle each consumed item:
+- **`type: "pause"`**: Print the note to the user, then use AskUserQuestion to
+  ask what they want to do (resume as planned / change direction / stop the
+  session). Do NOT dispatch the next sprint until the user answers.
+- **`type: "directive"`**: Surface the directive text verbatim ("Intercept
+  received: \"<directive>\"") and fold it into the next sprint direction.
+  If multiple directives, merge them into one coherent direction; if they
+  conflict, ask the user which takes precedence.
+
+Intercepts always take precedence over the originally planned direction.
+`consume` atomically marks items as processed, so running the check twice
+in one sprint is safe — the second call returns `[]`.
+
 **Between sprints — Backlog triage:** If new worker-sourced items appeared
 (check `BACKLOG_STATS` for `untriaged` count), review them:
 ```bash

--- a/scripts/intercept.py
+++ b/scripts/intercept.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""User intercept queue for autonomous-skill.
+
+Lets an external actor (user in another terminal, another agent, a cron job,
+etc.) inject directives or pause requests into a running session. The conductor
+consumes them at the start of each sprint's Plan phase.
+
+Stored in .autonomous/intercept.json, independent of conductor-state.json to
+avoid the PID lock on that file. mkdir-based atomic lock allows concurrent
+writers (user + conductor).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any, NoReturn
+
+VALID_TYPES = {"directive", "pause"}
+VALID_STATUS = {"pending", "consumed", "cleared"}
+MAX_DIRECTIVE_LEN = 2000
+
+
+def die(message: str) -> NoReturn:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def sanitize(text: str, limit: int = MAX_DIRECTIVE_LEN) -> str:
+    cleaned = re.sub(r"[\x00-\x08\x0b-\x1f\x7f]", "", text)
+    return cleaned[:limit]
+
+
+class InterceptLock:
+    def __init__(self, lock_dir: Path) -> None:
+        self.lock_dir = lock_dir
+        self.pid_file = lock_dir / "pid"
+        self.acquired = False
+
+    def acquire(self) -> None:
+        deadline = time.time() + 2
+        while True:
+            try:
+                self.lock_dir.mkdir(parents=True, exist_ok=False)
+                self.pid_file.write_text(str(os.getpid()))
+                self.acquired = True
+                return
+            except FileExistsError:
+                if time.time() >= deadline:
+                    pid = None
+                    if self.pid_file.exists():
+                        try:
+                            pid = int(self.pid_file.read_text().strip())
+                        except ValueError:
+                            pid = None
+                    if pid and pid_alive(pid):
+                        die(f"Intercept queue locked by PID {pid}")
+                    shutil.rmtree(self.lock_dir, ignore_errors=True)
+                    continue
+                time.sleep(0.1)
+
+    def release(self) -> None:
+        if self.acquired:
+            shutil.rmtree(self.lock_dir, ignore_errors=True)
+            self.acquired = False
+
+    def __enter__(self) -> "InterceptLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.release()
+
+
+class InterceptManager:
+    def __init__(self, project_dir: Path) -> None:
+        self.project = project_dir
+        self.state_dir = self.project / ".autonomous"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.queue_file = self.state_dir / "intercept.json"
+        self.conductor_state_file = self.state_dir / "conductor-state.json"
+        self.lock = InterceptLock(self.state_dir / "intercept.lock")
+
+    def load(self) -> dict[str, Any]:
+        if not self.queue_file.exists():
+            return {"version": 1, "items": []}
+        try:
+            data = json.loads(self.queue_file.read_text())
+            if not isinstance(data, dict) or "items" not in data:
+                return {"version": 1, "items": []}
+            return data
+        except (json.JSONDecodeError, OSError):
+            return {"version": 1, "items": []}
+
+    def save(self, data: dict[str, Any]) -> None:
+        tmp = self.queue_file.with_suffix(
+            self.queue_file.suffix + f".tmp.{os.getpid()}"
+        )
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(self.queue_file)
+
+    def current_session_id(self) -> str | None:
+        if not self.conductor_state_file.exists():
+            return None
+        try:
+            data = json.loads(self.conductor_state_file.read_text())
+            sid = data.get("session_id")
+            return sid if isinstance(sid, str) and sid else None
+        except (json.JSONDecodeError, OSError):
+            return None
+
+
+def _next_item_id(items: list[dict[str, Any]]) -> str:
+    ts = int(time.time())
+    return f"int-{ts}-{len(items) + 1}"
+
+
+def _is_current_scope(item: dict[str, Any], session_id: str | None) -> bool:
+    """An item is consumable if it matches the current session, or if it has
+    no session binding (queued before any session started)."""
+    item_session = item.get("session_id")
+    if item_session is None:
+        return True
+    return item_session == session_id
+
+
+def cmd_add(manager: InterceptManager, args: list[str]) -> None:
+    if not args:
+        die("Usage: intercept.py add <project-dir> <directive>")
+    directive = sanitize(args[0])
+    if not directive.strip():
+        die("directive is required")
+
+    with manager.lock:
+        state = manager.load()
+        items = state.setdefault("items", [])
+        item_id = _next_item_id(items)
+        items.append(
+            {
+                "id": item_id,
+                "type": "directive",
+                "directive": directive,
+                "status": "pending",
+                "session_id": manager.current_session_id(),
+                "created_at": now_iso(),
+                "consumed_at": None,
+                "consumed_in_sprint": None,
+            }
+        )
+        manager.save(state)
+    print(item_id)
+
+
+def cmd_pause(manager: InterceptManager, args: list[str]) -> None:
+    note = sanitize(args[0]) if args else ""
+
+    with manager.lock:
+        state = manager.load()
+        items = state.setdefault("items", [])
+        item_id = _next_item_id(items)
+        items.append(
+            {
+                "id": item_id,
+                "type": "pause",
+                "directive": note,
+                "status": "pending",
+                "session_id": manager.current_session_id(),
+                "created_at": now_iso(),
+                "consumed_at": None,
+                "consumed_in_sprint": None,
+            }
+        )
+        manager.save(state)
+    print(item_id)
+
+
+def cmd_list(manager: InterceptManager, args: list[str]) -> None:
+    scope = args[0] if args else "pending"
+    if scope not in {"pending", "consumed", "cleared", "all"}:
+        die(f"Invalid scope: {scope} (valid: pending, consumed, cleared, all)")
+
+    state = manager.load()
+    items = state.get("items", [])
+    if scope != "all":
+        items = [item for item in items if item.get("status") == scope]
+    print(json.dumps(items, indent=2))
+
+
+def cmd_status(manager: InterceptManager) -> None:
+    """One-line summary for the conductor's quick check. Counts only items
+    that are pending AND belong to the current session (or unbound)."""
+    state = manager.load()
+    session_id = manager.current_session_id()
+    pending = [
+        item
+        for item in state.get("items", [])
+        if item.get("status") == "pending" and _is_current_scope(item, session_id)
+    ]
+    if not pending:
+        print("none")
+        return
+    pause_count = sum(1 for item in pending if item.get("type") == "pause")
+    directive_count = len(pending) - pause_count
+    parts = []
+    if directive_count:
+        parts.append(f"{directive_count} directive")
+    if pause_count:
+        parts.append(f"{pause_count} pause")
+    print(" + ".join(parts))
+
+
+def cmd_consume(manager: InterceptManager, args: list[str]) -> None:
+    """Atomically mark pending items in the current session as consumed and
+    emit them as a JSON array. The conductor reads this to decide what to do."""
+    sprint_num: int | None
+    if args:
+        try:
+            sprint_num = int(args[0])
+        except ValueError:
+            die(f"sprint-num must be an integer, got: {args[0]}")
+    else:
+        sprint_num = None
+
+    with manager.lock:
+        state = manager.load()
+        session_id = manager.current_session_id()
+        now = now_iso()
+        consumed: list[dict[str, Any]] = []
+        for item in state.get("items", []):
+            if item.get("status") != "pending":
+                continue
+            if not _is_current_scope(item, session_id):
+                continue
+            item["status"] = "consumed"
+            item["consumed_at"] = now
+            item["consumed_in_sprint"] = sprint_num
+            consumed.append(dict(item))
+        manager.save(state)
+
+    print(json.dumps(consumed, indent=2))
+
+
+def cmd_clear(manager: InterceptManager) -> None:
+    with manager.lock:
+        state = manager.load()
+        session_id = manager.current_session_id()
+        now = now_iso()
+        cleared = 0
+        for item in state.get("items", []):
+            if item.get("status") == "pending" and _is_current_scope(item, session_id):
+                item["status"] = "cleared"
+                item["consumed_at"] = now
+                cleared += 1
+        manager.save(state)
+    print(f"cleared: {cleared}")
+
+
+def usage() -> None:
+    print(
+        """Usage: intercept.py <command> <project-dir> [args...]
+
+Commands:
+  add <project> <directive>   Queue a directive to merge into the next sprint
+  pause <project> [note]      Queue a pause request (conductor will stop and ask)
+  list <project> [scope]      List items (scope: pending|consumed|cleared|all, default pending)
+  status <project>            One-line summary ("none" or "N directive + M pause")
+  consume <project> [sprint]  Mark current-session pending items consumed, emit JSON
+  clear <project>             Mark current-session pending items cleared
+
+Typical workflow — user in another terminal interrupts a running session:
+  cd /path/to/project
+  python3 scripts/intercept.py add . "focus on the auth bug first"
+  python3 scripts/intercept.py pause . "I need to think about the design"
+""",
+        file=sys.stderr,
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) <= 1 or argv[1] in {"-h", "--help", "help"}:
+        usage()
+        return 0
+
+    cmd = argv[1]
+    project = Path(argv[2]) if len(argv) > 2 else Path(".")
+    args = argv[3:]
+    manager = InterceptManager(project)
+
+    if cmd == "add":
+        cmd_add(manager, args)
+    elif cmd == "pause":
+        cmd_pause(manager, args)
+    elif cmd == "list":
+        cmd_list(manager, args)
+    elif cmd == "status":
+        cmd_status(manager)
+    elif cmd == "consume":
+        cmd_consume(manager, args)
+    elif cmd == "clear":
+        cmd_clear(manager)
+    else:
+        die(f"Unknown command: {cmd}. Use: add|pause|list|status|consume|clear")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/tests/test_intercept.sh
+++ b/tests/test_intercept.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTERCEPT="$SCRIPT_DIR/../scripts/intercept.py"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_intercept.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── 1. Empty queue + help ─────────────────────────────────────────────────
+
+echo ""
+echo "1. Empty queue + help"
+
+T=$(new_tmp)
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_eq "$STATUS" "none" "empty queue reports 'none'"
+
+LIST=$(python3 "$INTERCEPT" list "$T" pending)
+assert_eq "$LIST" "[]" "empty queue lists empty array"
+
+HELP=$(python3 "$INTERCEPT" --help 2>&1)
+assert_contains "$HELP" "Usage: intercept.py" "--help shows usage"
+assert_contains "$HELP" "add <project>" "--help documents add"
+assert_contains "$HELP" "pause <project>" "--help documents pause"
+assert_contains "$HELP" "consume <project>" "--help documents consume"
+
+# ── 2. Add directive + pause ──────────────────────────────────────────────
+
+echo ""
+echo "2. Add directive + pause"
+
+T=$(new_tmp)
+ID1=$(python3 "$INTERCEPT" add "$T" "focus on auth bug")
+assert_contains "$ID1" "int-" "add directive returns ID with prefix"
+assert_file_exists "$T/.autonomous/intercept.json" "queue file created on first add"
+
+ID2=$(python3 "$INTERCEPT" pause "$T" "need to check design")
+assert_contains "$ID2" "int-" "pause returns ID"
+
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_contains "$STATUS" "1 directive" "status counts directive"
+assert_contains "$STATUS" "1 pause" "status counts pause"
+
+LIST=$(python3 "$INTERCEPT" list "$T" pending)
+assert_contains "$LIST" "focus on auth bug" "pending list includes directive text"
+assert_contains "$LIST" "need to check design" "pending list includes pause note"
+assert_contains "$LIST" '"type": "directive"' "item type is directive"
+assert_contains "$LIST" '"type": "pause"' "pause type preserved"
+
+# Pause with no note is allowed
+T2=$(new_tmp)
+ID_EMPTY=$(python3 "$INTERCEPT" pause "$T2")
+assert_contains "$ID_EMPTY" "int-" "pause allowed with no note"
+
+# Add with empty string fails (whitespace-only rejected)
+if python3 "$INTERCEPT" add "$T" "   " 2>/dev/null; then
+  fail "add with whitespace-only directive should fail"
+else
+  ok "add with whitespace-only directive rejected"
+fi
+
+# ── 3. Consume flow ───────────────────────────────────────────────────────
+
+echo ""
+echo "3. Consume flow"
+
+T=$(new_tmp)
+python3 "$INTERCEPT" add "$T" "first directive" > /dev/null
+python3 "$INTERCEPT" add "$T" "second directive" > /dev/null
+python3 "$INTERCEPT" pause "$T" "pause note" > /dev/null
+
+CONSUMED=$(python3 "$INTERCEPT" consume "$T" 5)
+assert_contains "$CONSUMED" "first directive" "consume emits first item"
+assert_contains "$CONSUMED" "second directive" "consume emits second item"
+assert_contains "$CONSUMED" "pause note" "consume emits pause item"
+assert_contains "$CONSUMED" '"consumed_in_sprint": 5' "sprint-num recorded"
+assert_contains "$CONSUMED" '"status": "consumed"' "items marked consumed in output"
+
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_eq "$STATUS" "none" "status none after consume"
+
+# Second consume returns empty (no double-fire)
+SECOND=$(python3 "$INTERCEPT" consume "$T" 6)
+assert_eq "$SECOND" "[]" "second consume returns empty (no double-fire)"
+
+# Persisted as consumed
+LIST_ALL=$(python3 "$INTERCEPT" list "$T" all)
+CONSUMED_COUNT=$(echo "$LIST_ALL" | grep -c '"status": "consumed"' || echo 0)
+assert_eq "$CONSUMED_COUNT" "3" "all three items persisted as consumed"
+
+# Consume with no sprint-num argument
+T=$(new_tmp)
+python3 "$INTERCEPT" add "$T" "solo" > /dev/null
+CONSUMED=$(python3 "$INTERCEPT" consume "$T")
+assert_contains "$CONSUMED" '"consumed_in_sprint": null' "missing sprint-num stored as null"
+
+# Consume with invalid sprint-num fails
+T=$(new_tmp)
+python3 "$INTERCEPT" add "$T" "solo" > /dev/null
+if python3 "$INTERCEPT" consume "$T" "not-a-number" 2>/dev/null; then
+  fail "consume with non-integer sprint should fail"
+else
+  ok "consume rejects non-integer sprint-num"
+fi
+
+# ── 4. Clear flow ─────────────────────────────────────────────────────────
+
+echo ""
+echo "4. Clear flow"
+
+T=$(new_tmp)
+python3 "$INTERCEPT" add "$T" "to be cleared" > /dev/null
+python3 "$INTERCEPT" add "$T" "also cleared" > /dev/null
+CLEARED=$(python3 "$INTERCEPT" clear "$T")
+assert_contains "$CLEARED" "cleared: 2" "clear reports count"
+
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_eq "$STATUS" "none" "status none after clear"
+
+# Cleared items don't fire on consume
+CONSUMED=$(python3 "$INTERCEPT" consume "$T" 1)
+assert_eq "$CONSUMED" "[]" "cleared items not consumed"
+
+# Cleared items visible under scope=cleared
+LIST_CLEARED=$(python3 "$INTERCEPT" list "$T" cleared)
+assert_contains "$LIST_CLEARED" "to be cleared" "cleared list shows items"
+
+# ── 5. Session scoping ────────────────────────────────────────────────────
+
+echo ""
+echo "5. Session scoping"
+
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+
+# No conductor state — item has session_id=null, gets consumed
+python3 "$INTERCEPT" add "$T" "pre-session item" > /dev/null
+LIST=$(python3 "$INTERCEPT" list "$T" pending)
+assert_contains "$LIST" '"session_id": null' "pre-session item has null session"
+
+# Write conductor state with session A
+cat > "$T/.autonomous/conductor-state.json" <<EOF
+{"session_id": "conductor-sessionA", "phase": "directed"}
+EOF
+
+# null-session item still consumable (unbound items pick up in first session)
+CONSUMED=$(python3 "$INTERCEPT" consume "$T" 1)
+assert_contains "$CONSUMED" "pre-session item" "null-session items consumed by current session"
+
+# Add item during session A — tagged with session A
+python3 "$INTERCEPT" add "$T" "session-A item" > /dev/null
+LIST=$(python3 "$INTERCEPT" list "$T" pending)
+assert_contains "$LIST" '"session_id": "conductor-sessionA"' "new item tagged with current session"
+
+# Switch to session B — session A's items no longer in scope
+cat > "$T/.autonomous/conductor-state.json" <<EOF
+{"session_id": "conductor-sessionB", "phase": "directed"}
+EOF
+
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_eq "$STATUS" "none" "session B ignores session A's items"
+
+CONSUMED=$(python3 "$INTERCEPT" consume "$T" 1)
+assert_eq "$CONSUMED" "[]" "session B consume does not drain session A items"
+
+# Session A items still visible under list-all
+LIST=$(python3 "$INTERCEPT" list "$T" all)
+assert_contains "$LIST" "session-A item" "session A items still visible via list-all"
+
+# ── 6. Concurrent writes ──────────────────────────────────────────────────
+
+echo ""
+echo "6. Concurrent writes"
+
+T=$(new_tmp)
+(python3 "$INTERCEPT" add "$T" "concurrent 1" > /dev/null) &
+(python3 "$INTERCEPT" add "$T" "concurrent 2" > /dev/null) &
+(python3 "$INTERCEPT" add "$T" "concurrent 3" > /dev/null) &
+wait
+
+COUNT=$(python3 -c "import json; d=json.load(open('$T/.autonomous/intercept.json')); print(len(d['items']))")
+assert_eq "$COUNT" "3" "all 3 concurrent writes succeeded"
+
+# No stale lock dir
+[ ! -d "$T/.autonomous/intercept.lock" ] && ok "no stale lock dir after concurrent writes" || fail "stale lock dir"
+
+# ── 7. Malformed state + corruption resilience ────────────────────────────
+
+echo ""
+echo "7. Malformed state + corruption"
+
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+echo "not json at all" > "$T/.autonomous/intercept.json"
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_eq "$STATUS" "none" "malformed queue treated as empty"
+
+# Add still works after corruption (overwrites bad file)
+ID=$(python3 "$INTERCEPT" add "$T" "after corruption")
+assert_contains "$ID" "int-" "add recovers after corrupted queue"
+
+# Malformed conductor state treated as no session
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+echo "{invalid" > "$T/.autonomous/conductor-state.json"
+python3 "$INTERCEPT" add "$T" "resilient add" > /dev/null
+LIST=$(python3 "$INTERCEPT" list "$T" pending)
+assert_contains "$LIST" '"session_id": null' "malformed conductor state falls back to null session"
+
+# ── 8. Input validation ───────────────────────────────────────────────────
+
+echo ""
+echo "8. Input validation"
+
+T=$(new_tmp)
+if python3 "$INTERCEPT" add "$T" 2>/dev/null; then
+  fail "add without directive should fail"
+else
+  ok "add without directive rejected"
+fi
+
+if python3 "$INTERCEPT" list "$T" invalid-scope 2>/dev/null; then
+  fail "list with invalid scope should fail"
+else
+  ok "list rejects invalid scope"
+fi
+
+if python3 "$INTERCEPT" unknowncmd "$T" 2>/dev/null; then
+  fail "unknown command should fail"
+else
+  ok "unknown command rejected"
+fi
+
+# Control characters stripped from directive
+T=$(new_tmp)
+printf -v EVIL 'clean\x01injected'
+python3 "$INTERCEPT" add "$T" "$EVIL" > /dev/null
+LIST=$(python3 "$INTERCEPT" list "$T" pending)
+# should contain "cleaninjected" (control char removed) but NOT the raw ctrl byte
+assert_contains "$LIST" "cleaninjected" "control characters stripped from directive"
+
+# Long directive truncated (MAX_DIRECTIVE_LEN = 2000)
+T=$(new_tmp)
+LONG=$(python3 -c "print('x' * 3000)")
+python3 "$INTERCEPT" add "$T" "$LONG" > /dev/null
+STORED_LEN=$(python3 -c "
+import json
+d = json.load(open('$T/.autonomous/intercept.json'))
+print(len(d['items'][0]['directive']))
+")
+assert_eq "$STORED_LEN" "2000" "long directive truncated to MAX_DIRECTIVE_LEN"
+
+# ── 9. status formatting ──────────────────────────────────────────────────
+
+echo ""
+echo "9. Status formatting"
+
+T=$(new_tmp)
+python3 "$INTERCEPT" add "$T" "a" > /dev/null
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_eq "$STATUS" "1 directive" "1 directive, no pause"
+
+python3 "$INTERCEPT" pause "$T" > /dev/null
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_eq "$STATUS" "1 directive + 1 pause" "1 each with both types"
+
+python3 "$INTERCEPT" add "$T" "b" > /dev/null
+python3 "$INTERCEPT" pause "$T" > /dev/null
+STATUS=$(python3 "$INTERCEPT" status "$T")
+assert_eq "$STATUS" "2 directive + 2 pause" "plural counts"
+
+print_results


### PR DESCRIPTION
## Summary

Lets an external terminal (user, cron job, another agent) steer a running autonomous session by queueing directives or pause requests. The conductor picks them up between sprints during Plan.

## Why

Users reported the need to interrupt a running session — change direction, pause for review, add a note — without killing the tmux window and losing in-flight work. `claude -p` has no stdin channel once launched, so we needed an out-of-band side channel.

## How it works

```bash
# From any terminal with filesystem access to the project:
python3 scripts/intercept.py add <project> "use Lucia for auth, not NextAuth"
python3 scripts/intercept.py pause <project> "I want to review the plan"
python3 scripts/intercept.py status <project>   # "2 directive + 1 pause" or "none"
python3 scripts/intercept.py clear <project>
```

- Queue lives in `.autonomous/intercept.json` (separate from conductor-state.json to avoid its PID lock)
- Conductor runs `status` + `consume` at the start of each Plan step
- **directive** items fold into the next sprint direction
- **pause** items stop the loop and trigger AskUserQuestion
- Worst-case latency: remainder of the current sprint (≤ `CC_TIMEOUT`)

## Design choices

| Decision | Why |
|---|---|
| Separate file, not a field on conductor-state | Avoid PID lock contention; user's CLI can write freely while conductor holds the lock |
| mkdir-based lock | Atomic, survives crashed writers (stale lock detection via PID) |
| session_id scoping | Intercepts from old sessions don't leak into new ones; unbound items (queued before any session) pick up in the first session |
| `consume` atomically marks items | Re-running in the same sprint is safe — second call returns `[]` |
| Control-char sanitize + 2KB truncate | Defense against accidental binary blobs or prompt injection payloads |

## Rejected alternative: claude-peers-mcp

I investigated [claude-peers-mcp](https://github.com/louislva/claude-peers-mcp) as a potential transport (channel-based push notifications directly into running sessions). Empirical test confirmed it doesn't work for our architecture: channel push does not reach `claude -p` headless sessions, and the polling server **consumes** the message during the failed push, so even `check_messages` returns nothing. Full investigation is in the commit message.

## Test plan

- [x] `bash tests/test_intercept.sh` — 50/50 passing
- [x] `python3 -m compileall scripts` — clean
- [x] All other suites unaffected (test_loop's 8 pre-existing failures also occur on `main`)
- [ ] Manual end-to-end: start `/autonomous`, queue an intercept from another terminal, verify conductor picks it up on next Plan step