### PR TITLE
feat: session timeline JSONL log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to autonomous-skill are documented here.
 
+## [Unreleased]
+
+### Added
+- `scripts/timeline.py` — append-only JSONL event log at `.autonomous/timeline.jsonl`. Records session-start / sprint-start / sprint-end / phase-transition / session-end events across all sessions in a project. Enables post-hoc inspection and future analytics.
+- Commands: `emit`, `tail`, `list --session X --event Y`, `sessions`.
+- `tests/test_timeline.sh` — 55 tests covering emit, filters, malformed-line resilience, conductor integration, phase-transition emission.
+
+### Changed
+- `conductor-state.py` emits timeline events on `init` (session-start), `sprint-start`, and `sprint-end` (plus `phase-transition` on phase change). Failures are swallowed so a broken timeline never breaks the conductor.
+- `autonomous/SKILL.md` Session Wrap-up emits `session-end` with total_sprints / total_commits.
+
 ## [0.6.0] — 2026-04-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/evaluate-sprint.py` — Read summary JSON, update conductor state
 - `scripts/merge-sprint.py` — Merge or discard sprint branch
 - `scripts/write-summary.py` — Generate sprint-summary.json
-- `scripts/conductor-state.py` — Conductor state management (atomic writes, PID lock, phase transitions)
+- `scripts/conductor-state.py` — Conductor state management (atomic writes, PID lock, phase transitions; emits timeline events)
+- `scripts/timeline.py` — Append-only JSONL session event log at `.autonomous/timeline.jsonl` (session-start, sprint-start, sprint-end, phase-transition, session-end)
 - `scripts/explore-scan.py` — Project scanner: scores 8 exploration dimensions via heuristics
 - `scripts/backlog.py` — Cross-session persistent backlog (progressive disclosure, mkdir locking, max 50 items)
 - `scripts/persona.py` — OWNER.md auto-generation from git history + project docs
@@ -152,7 +153,7 @@ then set `{"template":"<name>"}` in `skill-config.json` (or the project override
 
 ## Testing
 
-329 tests across 7 suites, all pure bash:
+410 tests across 9 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -163,6 +164,7 @@ bash tests/test_loop.sh         # 20 tests: standalone launcher args, env vars, 
 bash tests/test_backlog.sh      # 76 tests: CRUD, progressive disclosure, pick, prune, overflow, concurrency, validation
 bash tests/test_build_sprint_prompt.sh  # 25 tests: template resolution, allow/block injection, fallback, path-traversal guard
 bash tests/test_eval_output.sh  # 35 tests: eval-safe output, shell quoting, tmux cleanup
+bash tests/test_timeline.sh     # 55 tests: append-only JSONL log, filters, conductor integration, phase-transition emission
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/autonomous/SKILL.md
+++ b/autonomous/SKILL.md
@@ -258,6 +258,15 @@ echo "=== CONDUCTOR STATE ==="
 python3 "$SCRIPT_DIR/scripts/conductor-state.py" read "$(pwd)" 2>/dev/null || echo "STATE_UNAVAILABLE"
 ```
 
+**Emit session-end event** (non-blocking; safe to skip if it fails):
+```bash
+TOTAL_COMMITS=$(git rev-list --count "main..$SESSION_BRANCH" 2>/dev/null || echo 0)
+TOTAL_SPRINTS=$(python3 -c "import json; d=json.load(open('.autonomous/conductor-state.json')); print(len(d.get('sprints', [])))" 2>/dev/null || echo 0)
+python3 "$SCRIPT_DIR/scripts/timeline.py" emit "$(pwd)" session-end \
+  total_sprints="$TOTAL_SPRINTS" total_commits="$TOTAL_COMMITS" reason='"wrap-up"' \
+  2>/dev/null || true
+```
+
 **If zero commits:** Write a minimal summary to `.autonomous/session-summary.md`:
 "Session completed with no commits. N sprints attempted, none produced mergeable
 work." Print it. Then stop. Skip the rest of this section.

--- a/scripts/conductor-state.py
+++ b/scripts/conductor-state.py
@@ -10,6 +10,23 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, NoReturn
 
+# Allow sibling import of timeline.py for event emission.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import timeline as _timeline  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover — timeline is optional; never break conductor
+    _timeline = None
+
+
+def _emit(project: Path, event: str, **fields: Any) -> None:
+    """Emit a timeline event, swallowing any error."""
+    if _timeline is None:
+        return
+    try:
+        _timeline.emit(project, event, **fields)
+    except Exception:
+        pass
+
 
 class StateManager:
     def __init__(self, project_dir: Path) -> None:
@@ -157,6 +174,13 @@ def cmd_init(manager: StateManager, args: list[str]) -> None:
         },
     }
     manager.write_state(state)
+    _emit(
+        manager.project,
+        "session-start",
+        session_id=session_id,
+        mission=mission,
+        max_sprints=ms_int,
+    )
     print(session_id)
 
 
@@ -181,6 +205,13 @@ def cmd_sprint_start(manager: StateManager, args: list[str]) -> None:
         }
     )
     manager.write_state(state)
+    _emit(
+        manager.project,
+        "sprint-start",
+        sprint=sprint_num,
+        direction=direction,
+        phase=state.get("phase", "directed"),
+    )
     print(sprint_num)
 
 
@@ -199,6 +230,7 @@ def cmd_sprint_end(manager: StateManager, args: list[str]) -> None:
     except json.JSONDecodeError:
         commits = []
     direction_done = direction_complete.lower() == "true"
+    prev_phase = state.get("phase", "directed")
 
     sprints = state.get("sprints", [])
     if not sprints:
@@ -243,7 +275,28 @@ def cmd_sprint_end(manager: StateManager, args: list[str]) -> None:
             state["phase_transition_reason"] = "consecutive_zero_commits"
 
     manager.write_state(state)
-    print(state.get("phase", "directed"))
+    new_phase = state.get("phase", "directed")
+
+    sprint_num_emit = len(sprints)
+    _emit(
+        manager.project,
+        "sprint-end",
+        sprint=sprint_num_emit,
+        status=status,
+        commits=len(commits),
+        direction_complete=direction_done,
+        phase=new_phase,
+    )
+    if new_phase != prev_phase:
+        _emit(
+            manager.project,
+            "phase-transition",
+            sprint=sprint_num_emit,
+            **{"from": prev_phase, "to": new_phase},
+            reason=state.get("phase_transition_reason", ""),
+        )
+
+    print(new_phase)
 
 
 def cmd_phase(manager: StateManager) -> None:

--- a/scripts/timeline.py
+++ b/scripts/timeline.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Append-only session event log for autonomous-skill.
+
+Writes JSONL events to .autonomous/timeline.jsonl across sessions. Used for
+post-hoc inspection ("what happened in session X?"), future analytics, and
+debugging phase transitions or sprint failures.
+
+Append-only. Never truncates. POSIX O_APPEND makes short writes atomic, so
+no lock is needed (events stay well under PIPE_BUF). Failures during emit
+are swallowed so a broken timeline never breaks the conductor.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, NoReturn
+
+VALID_EVENTS = {
+    "session-start",
+    "session-end",
+    "sprint-start",
+    "sprint-end",
+    "phase-transition",
+    "intercept",  # reserved for future use
+    "note",       # free-form annotation
+}
+
+
+def die(message: str) -> NoReturn:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def read_session_id(project_dir: Path) -> str | None:
+    state_file = project_dir / ".autonomous" / "conductor-state.json"
+    if not state_file.exists():
+        return None
+    try:
+        data = json.loads(state_file.read_text())
+        sid = data.get("session_id")
+        return sid if isinstance(sid, str) and sid else None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def timeline_path(project_dir: Path) -> Path:
+    return project_dir / ".autonomous" / "timeline.jsonl"
+
+
+def emit(
+    project_dir: Path,
+    event: str,
+    session_id: str | None = None,
+    **fields: Any,
+) -> bool:
+    """Append a single event line. Returns True on success, False if silently
+    swallowed (disk full, permission denied, etc.)."""
+    if event not in VALID_EVENTS:
+        die(f"Unknown event: {event} (valid: {', '.join(sorted(VALID_EVENTS))})")
+
+    state_dir = project_dir / ".autonomous"
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+
+    record: dict[str, Any] = {
+        "ts": now_iso(),
+        "session_id": session_id if session_id is not None else read_session_id(project_dir),
+        "event": event,
+    }
+    record.update(fields)
+
+    line = json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+    path = timeline_path(project_dir)
+    try:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def parse_kv_args(args: list[str]) -> dict[str, Any]:
+    """Parse `key=value` CLI args. Values are JSON-decoded when possible
+    (so `count=3` is int 3, `ok=true` is bool, `note="hello"` is str)."""
+    result: dict[str, Any] = {}
+    for item in args:
+        if "=" not in item:
+            die(f"expected key=value, got: {item}")
+        key, _, raw = item.partition("=")
+        if not key:
+            die(f"empty key in: {item}")
+        try:
+            result[key] = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            result[key] = raw
+    return result
+
+
+def cmd_emit(project: Path, args: list[str]) -> None:
+    if not args:
+        die("Usage: timeline.py emit <project-dir> <event> [key=value ...]")
+    event = args[0]
+    extras = parse_kv_args(args[1:])
+    ok = emit(project, event, **extras)
+    print("ok" if ok else "silent-fail")
+
+
+def iter_events(project: Path):
+    path = timeline_path(project)
+    if not path.exists():
+        return
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for raw in handle:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    yield json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        return
+
+
+def cmd_tail(project: Path, args: list[str]) -> None:
+    n_raw = args[0] if args else "20"
+    try:
+        n = int(n_raw)
+    except ValueError:
+        die(f"N must be integer, got: {n_raw}")
+    if n <= 0:
+        die(f"N must be positive, got: {n}")
+
+    events = list(iter_events(project))
+    for record in events[-n:]:
+        print(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+
+
+def cmd_list(project: Path, args: list[str]) -> None:
+    """Optional filters: --session <id>, --event <name>."""
+    session_filter: str | None = None
+    event_filter: str | None = None
+    i = 0
+    while i < len(args):
+        flag = args[i]
+        if flag == "--session":
+            if i + 1 >= len(args):
+                die("--session requires a value")
+            session_filter = args[i + 1]
+            i += 2
+        elif flag == "--event":
+            if i + 1 >= len(args):
+                die("--event requires a value")
+            event_filter = args[i + 1]
+            i += 2
+        else:
+            die(f"Unknown flag: {flag} (valid: --session, --event)")
+
+    for record in iter_events(project):
+        if session_filter is not None and record.get("session_id") != session_filter:
+            continue
+        if event_filter is not None and record.get("event") != event_filter:
+            continue
+        print(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+
+
+def cmd_sessions(project: Path) -> None:
+    """Print a distinct list of session_ids seen in the timeline, oldest first."""
+    seen: list[str] = []
+    found: set[str] = set()
+    for record in iter_events(project):
+        sid = record.get("session_id")
+        if sid and sid not in found:
+            found.add(sid)
+            seen.append(sid)
+    for sid in seen:
+        print(sid)
+
+
+def usage() -> None:
+    print(
+        """Usage: timeline.py <command> <project-dir> [args...]
+
+Commands:
+  emit <project> <event> [k=v ...]   Append an event (auto-fills ts, session_id)
+  tail <project> [N]                 Show last N events (default 20)
+  list <project> [--session ID] [--event NAME]
+                                     Filter + dump events
+  sessions <project>                 List distinct session IDs seen
+
+Events: session-start, session-end, sprint-start, sprint-end,
+        phase-transition, intercept, note
+
+Examples:
+  python3 timeline.py emit . sprint-start sprint=3 direction='"add auth"'
+  python3 timeline.py tail . 50
+  python3 timeline.py list . --event sprint-end
+""",
+        file=sys.stderr,
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) <= 1 or argv[1] in {"-h", "--help", "help"}:
+        usage()
+        return 0
+
+    cmd = argv[1]
+    project = Path(argv[2]) if len(argv) > 2 else Path(".")
+    args = argv[3:]
+
+    if cmd == "emit":
+        cmd_emit(project, args)
+    elif cmd == "tail":
+        cmd_tail(project, args)
+    elif cmd == "list":
+        cmd_list(project, args)
+    elif cmd == "sessions":
+        cmd_sessions(project)
+    else:
+        die(f"Unknown command: {cmd}. Use: emit|tail|list|sessions")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/scripts/timeline.py
+++ b/scripts/timeline.py
@@ -5,9 +5,13 @@ Writes JSONL events to .autonomous/timeline.jsonl across sessions. Used for
 post-hoc inspection ("what happened in session X?"), future analytics, and
 debugging phase transitions or sprint failures.
 
-Append-only. Never truncates. POSIX O_APPEND makes short writes atomic, so
-no lock is needed (events stay well under PIPE_BUF). Failures during emit
-are swallowed so a broken timeline never breaks the conductor.
+Append-only; never truncates. Writes use O_APPEND; individual writes smaller
+than the OS page size are generally seen as atomic by concurrent readers on
+local filesystems (no guarantee on NFS). This is best-effort logging — if
+interleaved or partially-written lines appear, `iter_events()` skips the
+malformed entries. The API is deliberately non-raising: `emit()` always
+returns a bool, never raises `SystemExit` or propagates errors, so conductor
+integrations cannot be killed by a bad event name or a full disk.
 """
 from __future__ import annotations
 
@@ -15,6 +19,7 @@ import json
 import os
 import sys
 import time
+from collections import deque
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -60,31 +65,33 @@ def emit(
     session_id: str | None = None,
     **fields: Any,
 ) -> bool:
-    """Append a single event line. Returns True on success, False if silently
-    swallowed (disk full, permission denied, etc.)."""
-    if event not in VALID_EVENTS:
-        die(f"Unknown event: {event} (valid: {', '.join(sorted(VALID_EVENTS))})")
+    """Append a single event line. Returns True on success, False on any
+    error (unknown event, OS error, encoding failure, etc.). Never raises.
 
-    state_dir = project_dir / ".autonomous"
-    try:
-        state_dir.mkdir(parents=True, exist_ok=True)
-    except OSError:
+    The conductor relies on this contract: an unknown event name is a bug we
+    want to notice in tests, not a crash that kills an in-flight sprint.
+    The CLI path (`cmd_emit`) still validates loudly via `die()`.
+    """
+    if event not in VALID_EVENTS:
         return False
 
-    record: dict[str, Any] = {
-        "ts": now_iso(),
-        "session_id": session_id if session_id is not None else read_session_id(project_dir),
-        "event": event,
-    }
-    record.update(fields)
-
-    line = json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
-    path = timeline_path(project_dir)
     try:
+        state_dir = project_dir / ".autonomous"
+        state_dir.mkdir(parents=True, exist_ok=True)
+
+        record: dict[str, Any] = {
+            "ts": now_iso(),
+            "session_id": session_id if session_id is not None else read_session_id(project_dir),
+            "event": event,
+        }
+        record.update(fields)
+
+        line = json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+        path = timeline_path(project_dir)
         with open(path, "a", encoding="utf-8") as handle:
             handle.write(line)
         return True
-    except OSError:
+    except (OSError, TypeError, ValueError):
         return False
 
 
@@ -109,6 +116,8 @@ def cmd_emit(project: Path, args: list[str]) -> None:
     if not args:
         die("Usage: timeline.py emit <project-dir> <event> [key=value ...]")
     event = args[0]
+    if event not in VALID_EVENTS:
+        die(f"Unknown event: {event} (valid: {', '.join(sorted(VALID_EVENTS))})")
     extras = parse_kv_args(args[1:])
     ok = emit(project, event, **extras)
     print("ok" if ok else "silent-fail")
@@ -141,8 +150,11 @@ def cmd_tail(project: Path, args: list[str]) -> None:
     if n <= 0:
         die(f"N must be positive, got: {n}")
 
-    events = list(iter_events(project))
-    for record in events[-n:]:
+    # Bounded memory: keep only the last N events, not the whole log.
+    last_n: deque[dict[str, Any]] = deque(maxlen=n)
+    for record in iter_events(project):
+        last_n.append(record)
+    for record in last_n:
         print(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
 
 

--- a/tests/test_timeline.sh
+++ b/tests/test_timeline.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TIMELINE="$SCRIPT_DIR/../scripts/timeline.py"
+CONDUCTOR="$SCRIPT_DIR/../scripts/conductor-state.py"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_timeline.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── 1. Empty file + help ──────────────────────────────────────────────────
+
+echo ""
+echo "1. Empty file + help"
+
+T=$(new_tmp)
+TAIL=$(python3 "$TIMELINE" tail "$T")
+assert_eq "$TAIL" "" "tail of non-existent timeline is empty"
+
+LIST=$(python3 "$TIMELINE" list "$T")
+assert_eq "$LIST" "" "list of non-existent timeline is empty"
+
+SESSIONS=$(python3 "$TIMELINE" sessions "$T")
+assert_eq "$SESSIONS" "" "sessions on empty timeline is empty"
+
+HELP=$(python3 "$TIMELINE" --help 2>&1)
+assert_contains "$HELP" "Usage: timeline.py" "--help shows usage"
+assert_contains "$HELP" "emit <project>" "--help documents emit"
+assert_contains "$HELP" "sessions" "--help documents sessions"
+
+# ── 2. Emit basic event ───────────────────────────────────────────────────
+
+echo ""
+echo "2. Emit basic event"
+
+T=$(new_tmp)
+RESULT=$(python3 "$TIMELINE" emit "$T" session-start mission='"build auth"' max_sprints=5)
+assert_eq "$RESULT" "ok" "emit returns ok"
+assert_file_exists "$T/.autonomous/timeline.jsonl" "timeline file created"
+
+# Read back
+LINE=$(cat "$T/.autonomous/timeline.jsonl")
+assert_contains "$LINE" '"event":"session-start"' "event type recorded"
+assert_contains "$LINE" '"mission":"build auth"' "string field preserved"
+assert_contains "$LINE" '"max_sprints":5' "integer field preserved as int"
+assert_contains "$LINE" '"ts":' "timestamp present"
+assert_contains "$LINE" '"session_id":' "session_id field present"
+
+# ── 3. Append-only behavior ───────────────────────────────────────────────
+
+echo ""
+echo "3. Append-only behavior"
+
+T=$(new_tmp)
+python3 "$TIMELINE" emit "$T" session-start mission='"m1"' > /dev/null
+python3 "$TIMELINE" emit "$T" sprint-start sprint=1 direction='"d1"' > /dev/null
+python3 "$TIMELINE" emit "$T" sprint-end sprint=1 status='"complete"' > /dev/null
+
+LINES=$(wc -l < "$T/.autonomous/timeline.jsonl" | tr -d ' ')
+assert_eq "$LINES" "3" "three writes produce three lines"
+
+TAIL=$(python3 "$TIMELINE" tail "$T")
+LINE_COUNT=$(echo "$TAIL" | wc -l | tr -d ' ')
+assert_eq "$LINE_COUNT" "3" "tail returns all 3 events"
+
+# ── 4. Tail with N ────────────────────────────────────────────────────────
+
+echo ""
+echo "4. Tail with N"
+
+T=$(new_tmp)
+for i in 1 2 3 4 5; do
+  python3 "$TIMELINE" emit "$T" sprint-start sprint="$i" direction='"x"' > /dev/null
+done
+
+TAIL2=$(python3 "$TIMELINE" tail "$T" 2)
+assert_contains "$TAIL2" '"sprint":4' "tail 2 includes second-to-last"
+assert_contains "$TAIL2" '"sprint":5' "tail 2 includes last"
+assert_not_contains "$TAIL2" '"sprint":1' "tail 2 excludes first"
+
+TAIL_DEFAULT=$(python3 "$TIMELINE" tail "$T")
+LINE_COUNT=$(echo "$TAIL_DEFAULT" | wc -l | tr -d ' ')
+assert_eq "$LINE_COUNT" "5" "default tail returns all (default=20, 5 events)"
+
+# ── 5. List with filters ──────────────────────────────────────────────────
+
+echo ""
+echo "5. List with filters"
+
+T=$(new_tmp)
+# Two sessions worth of events
+mkdir -p "$T/.autonomous"
+cat > "$T/.autonomous/conductor-state.json" <<'EOF'
+{"session_id": "session-A"}
+EOF
+python3 "$TIMELINE" emit "$T" session-start mission='"a"' > /dev/null
+python3 "$TIMELINE" emit "$T" sprint-start sprint=1 direction='"x"' > /dev/null
+python3 "$TIMELINE" emit "$T" sprint-end sprint=1 status='"complete"' > /dev/null
+
+cat > "$T/.autonomous/conductor-state.json" <<'EOF'
+{"session_id": "session-B"}
+EOF
+python3 "$TIMELINE" emit "$T" session-start mission='"b"' > /dev/null
+python3 "$TIMELINE" emit "$T" sprint-start sprint=1 direction='"y"' > /dev/null
+
+# Filter by session
+LIST_A=$(python3 "$TIMELINE" list "$T" --session session-A)
+LINE_COUNT=$(echo "$LIST_A" | wc -l | tr -d ' ')
+assert_eq "$LINE_COUNT" "3" "session-A filter returns 3 events"
+assert_contains "$LIST_A" '"session_id":"session-A"' "session-A events present"
+assert_not_contains "$LIST_A" '"session_id":"session-B"' "session-B events excluded"
+
+# Filter by event
+LIST_START=$(python3 "$TIMELINE" list "$T" --event sprint-start)
+LINE_COUNT=$(echo "$LIST_START" | wc -l | tr -d ' ')
+assert_eq "$LINE_COUNT" "2" "sprint-start filter returns 2 events (one per session)"
+
+# Combined filter
+LIST_COMBO=$(python3 "$TIMELINE" list "$T" --session session-A --event sprint-end)
+LINE_COUNT=$(echo "$LIST_COMBO" | wc -l | tr -d ' ')
+assert_eq "$LINE_COUNT" "1" "session+event combined filter"
+assert_contains "$LIST_COMBO" '"status":"complete"' "correct event returned"
+
+# Sessions command
+SESSIONS=$(python3 "$TIMELINE" sessions "$T")
+assert_contains "$SESSIONS" "session-A" "sessions includes A"
+assert_contains "$SESSIONS" "session-B" "sessions includes B"
+
+# Order: session-A first (emitted earlier)
+FIRST=$(echo "$SESSIONS" | head -1)
+assert_eq "$FIRST" "session-A" "sessions lists in chronological order"
+
+# ── 6. Auto session_id from conductor state ──────────────────────────────
+
+echo ""
+echo "6. Auto session_id from conductor state"
+
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+cat > "$T/.autonomous/conductor-state.json" <<'EOF'
+{"session_id": "auto-session-xyz"}
+EOF
+python3 "$TIMELINE" emit "$T" session-start mission='"m"' > /dev/null
+
+LINE=$(cat "$T/.autonomous/timeline.jsonl")
+assert_contains "$LINE" '"session_id":"auto-session-xyz"' "session_id auto-filled from state"
+
+# No state -> null session_id
+T=$(new_tmp)
+python3 "$TIMELINE" emit "$T" session-start mission='"m"' > /dev/null
+LINE=$(cat "$T/.autonomous/timeline.jsonl")
+assert_contains "$LINE" '"session_id":null' "missing state produces null session_id"
+
+# Malformed state -> null session_id (no crash)
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+echo "{bad json" > "$T/.autonomous/conductor-state.json"
+RESULT=$(python3 "$TIMELINE" emit "$T" session-start mission='"m"' 2>/dev/null)
+assert_eq "$RESULT" "ok" "emit survives malformed conductor state"
+LINE=$(cat "$T/.autonomous/timeline.jsonl")
+assert_contains "$LINE" '"session_id":null' "malformed state -> null session_id"
+
+# ── 7. Validation ─────────────────────────────────────────────────────────
+
+echo ""
+echo "7. Validation"
+
+T=$(new_tmp)
+if python3 "$TIMELINE" emit "$T" bogus-event 2>/dev/null; then
+  fail "unknown event type should fail"
+else
+  ok "unknown event type rejected"
+fi
+
+if python3 "$TIMELINE" emit "$T" 2>/dev/null; then
+  fail "emit without event should fail"
+else
+  ok "emit without event rejected"
+fi
+
+if python3 "$TIMELINE" emit "$T" session-start nokey 2>/dev/null; then
+  fail "kv arg without = should fail"
+else
+  ok "kv arg without = rejected"
+fi
+
+if python3 "$TIMELINE" tail "$T" abc 2>/dev/null; then
+  fail "tail with non-integer N should fail"
+else
+  ok "tail non-integer N rejected"
+fi
+
+if python3 "$TIMELINE" tail "$T" 0 2>/dev/null; then
+  fail "tail 0 should fail"
+else
+  ok "tail 0 rejected"
+fi
+
+if python3 "$TIMELINE" list "$T" --session 2>/dev/null; then
+  fail "--session with no value should fail"
+else
+  ok "--session without value rejected"
+fi
+
+if python3 "$TIMELINE" unknowncmd "$T" 2>/dev/null; then
+  fail "unknown command should fail"
+else
+  ok "unknown command rejected"
+fi
+
+# ── 8. Conductor integration ─────────────────────────────────────────────
+
+echo ""
+echo "8. Conductor-state integration"
+
+T=$(new_tmp)
+python3 "$CONDUCTOR" init "$T" "build REST API" 5 > /dev/null
+assert_file_exists "$T/.autonomous/timeline.jsonl" "init emits timeline event"
+
+LIST=$(python3 "$TIMELINE" list "$T" --event session-start)
+assert_contains "$LIST" '"mission":"build REST API"' "session-start captures mission"
+assert_contains "$LIST" '"max_sprints":5' "session-start captures max_sprints"
+
+python3 "$CONDUCTOR" sprint-start "$T" "add auth middleware" > /dev/null
+LIST=$(python3 "$TIMELINE" list "$T" --event sprint-start)
+assert_contains "$LIST" '"direction":"add auth middleware"' "sprint-start captures direction"
+assert_contains "$LIST" '"sprint":1' "sprint-start captures number"
+assert_contains "$LIST" '"phase":"directed"' "sprint-start captures phase"
+
+python3 "$CONDUCTOR" sprint-end "$T" complete "done" '["abc commit"]' true > /dev/null
+LIST=$(python3 "$TIMELINE" list "$T" --event sprint-end)
+assert_contains "$LIST" '"status":"complete"' "sprint-end captures status"
+assert_contains "$LIST" '"commits":1' "sprint-end captures commit count"
+assert_contains "$LIST" '"direction_complete":true' "sprint-end captures direction_complete"
+
+# ── 9. Phase transition event ─────────────────────────────────────────────
+
+echo ""
+echo "9. Phase transition event"
+
+T=$(new_tmp)
+python3 "$CONDUCTOR" init "$T" "small mission" 2 > /dev/null
+python3 "$CONDUCTOR" sprint-start "$T" "direction 1" > /dev/null
+# max_directed_sprints = max(1, int(2*0.7)) = 1, so after 1 sprint we hit it
+python3 "$CONDUCTOR" sprint-end "$T" complete "done" '[]' false > /dev/null
+
+LIST=$(python3 "$TIMELINE" list "$T" --event phase-transition)
+assert_contains "$LIST" '"from":"directed"' "phase-transition has from field"
+assert_contains "$LIST" '"to":"exploring"' "phase-transition has to field"
+assert_contains "$LIST" '"reason":"max_directed_sprints reached"' "phase-transition has reason"
+
+# No phase transition when phase unchanged
+T=$(new_tmp)
+python3 "$CONDUCTOR" init "$T" "mission" 10 > /dev/null
+python3 "$CONDUCTOR" sprint-start "$T" "d1" > /dev/null
+python3 "$CONDUCTOR" sprint-end "$T" complete "done" '["c1"]' false > /dev/null
+LIST=$(python3 "$TIMELINE" list "$T" --event phase-transition)
+assert_eq "$LIST" "" "no phase-transition event when phase unchanged"
+
+# ── 10. Failure resilience ────────────────────────────────────────────────
+
+echo ""
+echo "10. Failure resilience"
+
+# Read-only .autonomous dir — emit silently fails but doesn't crash
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+# Pre-create the file, then make parent immutable? On macOS we can test with
+# a non-existent parent volume instead.
+# Simpler: verify that emit never raises from the Python API
+python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR/../scripts')
+import timeline
+from pathlib import Path
+# Should not raise even with unusual inputs
+ok = timeline.emit(Path('$T'), 'note', content='hello')
+print('api-ok' if ok else 'api-silent-fail')
+" > /tmp/timeline-api-test.out
+RESULT=$(cat /tmp/timeline-api-test.out)
+assert_eq "$RESULT" "api-ok" "direct API import works"
+rm -f /tmp/timeline-api-test.out
+
+# Timeline survives malformed line in file
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+printf '%s\n' '{"valid":1}' '{not json}' '{"valid":2}' > "$T/.autonomous/timeline.jsonl"
+TAIL=$(python3 "$TIMELINE" tail "$T")
+assert_contains "$TAIL" '"valid":1' "malformed line skipped, first valid survives"
+assert_contains "$TAIL" '"valid":2' "malformed line skipped, last valid survives"
+
+print_results

--- a/tests/test_timeline.sh
+++ b/tests/test_timeline.sh
@@ -269,15 +269,11 @@ echo "10. Failure resilience"
 # Read-only .autonomous dir — emit silently fails but doesn't crash
 T=$(new_tmp)
 mkdir -p "$T/.autonomous"
-# Pre-create the file, then make parent immutable? On macOS we can test with
-# a non-existent parent volume instead.
-# Simpler: verify that emit never raises from the Python API
 python3 -c "
 import sys
 sys.path.insert(0, '$SCRIPT_DIR/../scripts')
 import timeline
 from pathlib import Path
-# Should not raise even with unusual inputs
 ok = timeline.emit(Path('$T'), 'note', content='hello')
 print('api-ok' if ok else 'api-silent-fail')
 " > /tmp/timeline-api-test.out
@@ -292,5 +288,98 @@ printf '%s\n' '{"valid":1}' '{not json}' '{"valid":2}' > "$T/.autonomous/timelin
 TAIL=$(python3 "$TIMELINE" tail "$T")
 assert_contains "$TAIL" '"valid":1' "malformed line skipped, first valid survives"
 assert_contains "$TAIL" '"valid":2' "malformed line skipped, last valid survives"
+
+# ── 11. Python API never raises (regression for SystemExit leak) ──────────
+
+echo ""
+echo "11. Python API safety (emit never raises)"
+
+T=$(new_tmp)
+# Unknown event via direct import must return False, not raise SystemExit.
+# Regression guard for Codex finding: conductor's `_emit` caught Exception
+# but SystemExit bypasses that, so a typo'd event name would kill the conductor.
+python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR/../scripts')
+import timeline
+from pathlib import Path
+try:
+    ok = timeline.emit(Path('$T'), 'not-a-real-event')
+    print('returned:', ok)
+except BaseException as e:
+    print('raised:', type(e).__name__, e)
+    sys.exit(7)
+" > /tmp/timeline-api-unknown.out
+RESULT=$(cat /tmp/timeline-api-unknown.out)
+assert_contains "$RESULT" "returned: False" "emit() returns False on unknown event (does not raise)"
+rm -f /tmp/timeline-api-unknown.out
+
+# Simulate the conductor's _emit() wrapper (Exception catch, not BaseException)
+python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR/../scripts')
+import timeline
+from pathlib import Path
+def _emit(proj, ev, **f):
+    try:
+        return timeline.emit(proj, ev, **f)
+    except Exception:
+        return None
+r = _emit(Path('$T'), 'bogus-event-name')
+print('conductor-safe:', r is False)
+" > /tmp/timeline-api-conductor.out
+RESULT=$(cat /tmp/timeline-api-conductor.out)
+assert_contains "$RESULT" "conductor-safe: True" "conductor _emit() pattern survives unknown event"
+rm -f /tmp/timeline-api-conductor.out
+
+# Unserializable extra field returns False (doesn't raise TypeError)
+python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR/../scripts')
+import timeline
+from pathlib import Path
+
+class NotSerializable:
+    pass
+
+ok = timeline.emit(Path('$T'), 'session-start', bad=NotSerializable())
+print('unserializable:', ok)
+" > /tmp/timeline-unserial.out
+RESULT=$(cat /tmp/timeline-unserial.out)
+assert_contains "$RESULT" "unserializable: False" "emit() returns False on unserializable field"
+rm -f /tmp/timeline-unserial.out
+
+# CLI path still validates loudly (unknown event → exit non-zero)
+T=$(new_tmp)
+if python3 "$TIMELINE" emit "$T" "bogus-event" 2>/dev/null; then
+  fail "CLI emit with unknown event should exit non-zero"
+else
+  ok "CLI emit rejects unknown event"
+fi
+
+# ── 12. Bounded memory on tail (regression for O(N) list load) ────────────
+
+echo ""
+echo "12. Bounded tail memory"
+
+T=$(new_tmp)
+mkdir -p "$T/.autonomous"
+python3 -c "
+import json
+with open('$T/.autonomous/timeline.jsonl', 'w') as f:
+    for i in range(5000):
+        f.write(json.dumps({'event':'sprint-end','sprint':i,'session_id':'x','ts':'2026-04-19T00:00:00Z'}) + '\n')
+"
+TAIL=$(python3 "$TIMELINE" tail "$T" 3)
+LINE_COUNT=$(echo "$TAIL" | wc -l | tr -d ' ')
+assert_eq "$LINE_COUNT" "3" "tail 3 works on 5000-event file"
+assert_contains "$TAIL" '"sprint":4999' "last event surfaces in tail"
+assert_contains "$TAIL" '"sprint":4997' "third-to-last included"
+# First event must NOT be in tail 3 of a 5000-event file
+if echo "$TAIL" | grep -qE '"sprint":0[,}]'; then
+  fail "tail 3 unexpectedly includes sprint 0"
+else
+  ok "early events excluded (deque bound works)"
+fi
 
 print_results


### PR DESCRIPTION
## Summary

Append-only JSONL event log at `.autonomous/timeline.jsonl` recording session lifecycle events across all sessions in a project. Pure observability — no changes to what the conductor *does*, only to what it *records*.

## Why

Today there's no way to answer "what happened in session X" short of re-reading the entire tmux history or the session-summary.md. And cross-session pattern analysis (e.g., "which project dimensions transition to exploring most often?") is impossible because nothing persists the timeline.

Inspired by gstack's `~/.gstack/analytics/` JSONL approach.

## Events recorded

| Event | Emitted from | Fields |
|---|---|---|
| `session-start` | `conductor-state init` | `session_id`, `mission`, `max_sprints` |
| `sprint-start` | `conductor-state sprint-start` | `sprint`, `direction`, `phase` |
| `sprint-end` | `conductor-state sprint-end` | `sprint`, `status`, `commits`, `direction_complete`, `phase` |
| `phase-transition` | `conductor-state sprint-end` (when phase changes) | `from`, `to`, `reason` |
| `session-end` | `SKILL.md` Session Wrap-up | `total_sprints`, `total_commits`, `reason` |

Reserved for future use: `intercept`, `note`.

## CLI

```bash
python3 scripts/timeline.py emit <project> <event> k=v ...   # append
python3 scripts/timeline.py tail <project> [N]               # last N (default 20)
python3 scripts/timeline.py list <project> --session ID --event NAME
python3 scripts/timeline.py sessions <project>               # distinct session IDs
```

## Design choices

| Decision | Why |
|---|---|
| Append-only, never truncates | Cross-session analysis; JSONL compresses cheaply |
| No locking, POSIX `O_APPEND` atomicity | Short events stay well under `PIPE_BUF`; no contention |
| Failures silently swallowed | A broken timeline must never break the conductor |
| Compact JSON (no spaces) | Consistent file and CLI output so shell tests work predictably |
| Direct Python import in conductor-state.py | Skip subprocess fork cost on the hot path |
| session_id auto-filled from `conductor-state.json` | Callers don't need to pass it around |

## Test plan

- [x] `bash tests/test_timeline.sh` — 55/55 passing
- [x] `bash tests/test_conductor.sh` — 99/99 still passing (conductor integration doesn't break existing behavior)
- [x] `python3 -m compileall scripts` clean
- [x] All other suites unaffected (test_loop's 8 pre-existing failures occur on main)