### PR TITLE
feat: checkpoint.py — human-readable session snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,8 @@ All notable changes to autonomous-skill are documented here.
 ## [Unreleased]
 
 ### Added
-- `scripts/hooks/careful.sh` — PreToolUse Bash hook for autonomous workers. Blocks catastrophic patterns (rm -rf /, rm -rf $HOME/~, /Users, /home, dd to raw device, mkfs, fork bomb, device redirects, shutdown/reboot/halt, git force-push, DROP TABLE/DATABASE/SCHEMA, TRUNCATE). Covers first-word bypass (`echo ok; rm -rf /`, `env rm -rf /`) by running all destructive checks regardless of the leading command.
-- `tests/test_careful_hook.sh` — 97 tests covering safe commands, catastrophic patterns, build-artifact exceptions, SQL, force-push, fork bomb, non-Bash input, adversarial bypass attempts (chaining, wrapper execs, flag separators), and dispatch integration.
-
-### Changed
-- `scripts/dispatch.py` — when `AUTONOMOUS_WORKER_CAREFUL=1` (or `true`/`yes`), writes a per-session `.autonomous/settings-<window>.json` registering the careful hook and passes `--settings <path>` to the worker's `claude` invocation. `window_name` validated against `^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$` to block path-traversal and shell injection. Wrapper uses `shlex.quote()` for all interpolated paths. Opt-in; default remains off.
+- `scripts/checkpoint.py` — human-readable session snapshots. `save`/`list`/`latest`/`show` commands write markdown files (with YAML frontmatter) to `.autonomous/checkpoints/<ts>-<slug>.md`. Captures mission, phase, sprint history, exploration dimensions, backlog summary, git state, and resume guidance. Rejects path-traversal and glob-injection in `show`; all YAML scalars are JSON-quoted to resist frontmatter injection; `read_json` enforces dict shape.
+- `tests/test_checkpoint.sh` — 70 tests covering save/list/latest/show flows, same-second collision handling, path-traversal rejection, YAML injection resistance, type-unsafe JSON states, non-UTF8 checkpoints, unicode titles.
 
 ## [0.6.0] — 2026-04-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/timeline.py` — Append-only JSONL session event log at `.autonomous/timeline.jsonl` (session-start, sprint-start, sprint-end, phase-transition, session-end)
 - `scripts/explore-scan.py` — Project scanner: scores 8 exploration dimensions via heuristics
 - `scripts/backlog.py` — Cross-session persistent backlog (progressive disclosure, mkdir locking, max 50 items)
+- `scripts/checkpoint.py` — Human-readable markdown snapshots of session state at `.autonomous/checkpoints/<ts>-<slug>.md` (save/list/latest/show)
 - `scripts/persona.py` — OWNER.md auto-generation from git history + project docs
 - `scripts/loop.py` — Standalone launcher (outside CC's skill system)
 - `scripts/master-poll.py` — Manual master polling for comms.json
@@ -154,7 +155,7 @@ then set `{"template":"<name>"}` in `skill-config.json` (or the project override
 
 ## Testing
 
-515 tests across 10 suites, all pure bash:
+585 tests across 11 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -167,6 +168,7 @@ bash tests/test_build_sprint_prompt.sh  # 25 tests: template resolution, allow/b
 bash tests/test_eval_output.sh  # 35 tests: eval-safe output, shell quoting, tmux cleanup
 bash tests/test_timeline.sh     # 63 tests: append-only JSONL log, filters, conductor integration, phase-transition emission, non-raising emit, bounded tail
 bash tests/test_careful_hook.sh # 97 tests: PreToolUse hook pattern matching, adversarial bypasses, dispatch integration, window_name validation
+bash tests/test_checkpoint.sh   # 70 tests: save/list/latest/show, path-traversal rejection, YAML injection resistance, type-unsafe JSON, non-UTF8
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/README.md
+++ b/README.md
@@ -192,11 +192,24 @@ Set `AUTONOMOUS_WORKER_CAREFUL=1` to install a PreToolUse hook on every dispatch
 AUTONOMOUS_WORKER_CAREFUL=1 /autonomous 5 build REST API
 ```
 
-Blocks: `rm -rf /`, `rm -rf $HOME`, `rm -rf /Users|/home`, `mkfs`, `dd of=/dev/sd*`, fork bombs, device redirects, `shutdown`/`reboot`, `git push --force` to `main`/`master`/`trunk`/`release`, `DROP TABLE/DATABASE/SCHEMA`, `TRUNCATE TABLE`.
-
-Search/view tools (`grep DROP foo.sql`, `echo rm -rf /`) are recognized by first-word whitelist and allowed. Ordinary `rm -rf node_modules` and similar build-artifact cleanup pass through.
+Blocks: `rm -rf /`, `rm -rf $HOME`, `rm -rf /Users|/home`, `mkfs`, `dd of=/dev/sd*`, fork bombs, device redirects (`>`, `>>`, `>|`, `tee`, `cp` to `/dev/*`), `shutdown`/`reboot`, `git push --force` (all variants), `DROP TABLE/DATABASE/SCHEMA`, `TRUNCATE TABLE`. Also catches interpreter wrappers like `python3 -c 'os.system("rm -rf /")'` and chaining bypasses like `echo ok; rm -rf /`.
 
 Configured per-sprint via `claude --settings <file>` — no global settings change. Blocks are exit-2 with a stderr message; the worker reads "BLOCKED: ..." and adapts.
+
+### Checkpoints
+
+Take a human-readable snapshot of the current session anytime:
+
+```bash
+python3 ~/.claude/skills/autonomous-skill/scripts/checkpoint.py save .
+python3 ~/.claude/skills/autonomous-skill/scripts/checkpoint.py save . --title "pre-refactor"
+python3 ~/.claude/skills/autonomous-skill/scripts/checkpoint.py list .
+python3 ~/.claude/skills/autonomous-skill/scripts/checkpoint.py latest .
+```
+
+Each checkpoint is a markdown file at `.autonomous/checkpoints/<ts>-<slug>.md` capturing mission, phase, sprint history, backlog summary, exploration dimension scores, git state, and resume guidance. History is retained — old checkpoints stay until manually deleted.
+
+Useful for context switching ("where was I yesterday?"), sharing session state with a teammate, or reviewing sprint output before resuming.
 
 
 ## Configuration

--- a/scripts/checkpoint.py
+++ b/scripts/checkpoint.py
@@ -39,10 +39,17 @@ def slugify(text: str, max_len: int = 40) -> str:
 
 
 def read_json(path: Path) -> dict[str, Any]:
+    """Load a JSON file as a dict. Returns {} on any failure — missing file,
+    malformed JSON, wrong top-level type, encoding errors. Callers assume
+    dict shape and use .get() extensively, so non-dict payloads must be
+    filtered out here rather than crash downstream."""
     try:
-        return json.loads(path.read_text())
-    except (json.JSONDecodeError, OSError, FileNotFoundError):
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, FileNotFoundError, UnicodeDecodeError):
         return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
 
 
 def git(project: Path, *args: str) -> str:
@@ -91,6 +98,36 @@ def format_sprint(sprint: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _yaml_scalar(value: Any) -> str:
+    """Serialize any value as a YAML-safe scalar. JSON is a YAML subset so
+    `json.dumps` produces a valid YAML string literal for any input, and
+    handles newlines, colons, `#`, leading `[`/`{`, unicode escapes. Used
+    instead of raw f-string interpolation to prevent frontmatter injection
+    if conductor-state fields contain YAML-hostile characters."""
+    return json.dumps(value if value is not None else "", ensure_ascii=False)
+
+
+def _safe_shape(state: dict[str, Any]) -> dict[str, Any]:
+    """Coerce nested state fields to the shape the renderer expects. Covers
+    the case where conductor-state.json is valid JSON but has wrong types
+    (sprints as dict, exploration as list, etc.) after a refactor or
+    corruption."""
+    sprints = state.get("sprints")
+    if not isinstance(sprints, list):
+        sprints = []
+    exploration = state.get("exploration")
+    if not isinstance(exploration, dict):
+        exploration = {}
+    return {
+        "session_id": state.get("session_id") or "(no session)",
+        "mission": state.get("mission") or "(no mission)",
+        "phase": state.get("phase") or "unknown",
+        "sprints": [s for s in sprints if isinstance(s, dict)],
+        "max_sprints": state.get("max_sprints", "?"),
+        "exploration": {k: v for k, v in exploration.items() if isinstance(v, dict)},
+    }
+
+
 def render_markdown(
     project: Path,
     state: dict[str, Any],
@@ -99,19 +136,24 @@ def render_markdown(
     title: str,
     saved_at: str,
 ) -> str:
-    session_id = state.get("session_id", "(no session)")
-    mission = state.get("mission", "(no mission)")
-    phase = state.get("phase", "unknown")
-    sprints = state.get("sprints", [])
-    max_sprints = state.get("max_sprints", "?")
-    exploration = state.get("exploration", {})
+    safe = _safe_shape(state)
+    session_id = safe["session_id"]
+    mission = safe["mission"]
+    phase = safe["phase"]
+    sprints = safe["sprints"]
+    max_sprints = safe["max_sprints"]
+    exploration = safe["exploration"]
 
     total_commits = sum(
         len(s.get("commits", [])) for s in sprints if isinstance(s.get("commits"), list)
     )
 
+    backlog_items = backlog.get("items")
+    if not isinstance(backlog_items, list):
+        backlog_items = []
     open_items = [
-        item for item in backlog.get("items", []) if item.get("status") == "open"
+        item for item in backlog_items
+        if isinstance(item, dict) and item.get("status") == "open"
     ]
     untriaged = sum(1 for item in open_items if not item.get("triaged", True))
     next_item = None
@@ -124,17 +166,20 @@ def render_markdown(
 
     lines: list[str] = []
 
-    # YAML frontmatter — for parseability if we later want to diff checkpoints
+    # YAML frontmatter — every scalar goes through _yaml_scalar to prevent
+    # injection if a field contains `:`, newlines, `#`, leading `[`/`{`,
+    # or other YAML-hostile characters. JSON is a YAML subset so quoted JSON
+    # strings are valid YAML strings.
     lines.append("---")
-    lines.append(f"saved_at: {saved_at}")
-    lines.append(f"session_id: {session_id}")
-    lines.append(f"session_branch: {git_state.get('current_branch', '')}")
-    lines.append(f"phase: {phase}")
+    lines.append(f"saved_at: {_yaml_scalar(saved_at)}")
+    lines.append(f"session_id: {_yaml_scalar(session_id)}")
+    lines.append(f"session_branch: {_yaml_scalar(git_state.get('current_branch', ''))}")
+    lines.append(f"phase: {_yaml_scalar(phase)}")
     lines.append(f"sprint_count: {len(sprints)}")
-    lines.append(f"max_sprints: {max_sprints}")
+    lines.append(f"max_sprints: {max_sprints if isinstance(max_sprints, (int, str)) else '?'}")
     lines.append(f"commit_count: {total_commits}")
     lines.append(f"backlog_open: {len(open_items)}")
-    lines.append(f"title: {json.dumps(title)}")
+    lines.append(f"title: {_yaml_scalar(title)}")
     lines.append("---")
     lines.append("")
 
@@ -249,26 +294,35 @@ def cmd_save(project: Path, args: list[str]) -> None:
     backlog = read_json(project / ".autonomous" / "backlog.json")
     git_state = gather_git_state(project)
 
-    # Auto-generate title if none provided
+    # Auto-generate title if none provided. Use _safe_shape so a malformed
+    # sprints field (dict, scalar, missing) can't crash title generation.
     if not title:
-        sprints = state.get("sprints", [])
-        if sprints:
-            last = sprints[-1]
-            title = f"sprint {last.get('number', len(sprints))} — {last.get('status', 'unknown')}"
+        safe = _safe_shape(state)
+        sprints_safe = safe["sprints"]
+        if sprints_safe:
+            last = sprints_safe[-1]
+            title = f"sprint {last.get('number', len(sprints_safe))} — {last.get('status', 'unknown')}"
         else:
             title = "session-start"
 
     saved_at = now_iso()
     ts_filename = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
     slug = slugify(title)
-    filename = f"{ts_filename}-{slug}.md"
 
     ckpt_dir = project / ".autonomous" / "checkpoints"
     ckpt_dir.mkdir(parents=True, exist_ok=True)
-    target = ckpt_dir / filename
+
+    # Same-second same-slug saves previously silently overwrote. Add a
+    # numeric suffix (-1, -2, ...) if the target already exists.
+    base = f"{ts_filename}-{slug}"
+    target = ckpt_dir / f"{base}.md"
+    seq = 1
+    while target.exists():
+        target = ckpt_dir / f"{base}-{seq}.md"
+        seq += 1
 
     content = render_markdown(project, state, backlog, git_state, title, saved_at)
-    target.write_text(content)
+    target.write_text(content, encoding="utf-8")
     print(str(target))
 
 
@@ -281,18 +335,41 @@ def cmd_list(project: Path, args: list[str]) -> None:
     for f in files:
         # Print: filename\ttitle (if parseable from frontmatter)
         try:
-            head = f.read_text().splitlines()[:20]
+            head = f.read_text(encoding="utf-8", errors="replace").splitlines()[:20]
         except OSError:
             head = []
         title_val = ""
         for line in head:
             if line.startswith("title: "):
-                title_val = line[len("title: "):].strip().strip('"')
+                raw = line[len("title: "):].strip()
+                # Titles are written as JSON strings (_yaml_scalar). Decode
+                # JSON to get the human-readable title back; fall back to the
+                # raw string if parsing fails (older checkpoints, manual edits).
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, str):
+                        title_val = parsed
+                    else:
+                        title_val = raw
+                except (json.JSONDecodeError, ValueError):
+                    title_val = raw.strip('"')
                 break
+        # Collapse any newlines in the title — tab-delimited output would
+        # otherwise break downstream parsers.
+        title_val = title_val.replace("\n", " ").replace("\r", " ")
         if title_val:
             print(f"{f.name}\t{title_val}")
         else:
             print(f.name)
+
+
+def _safe_read(path: Path) -> str:
+    """Read a checkpoint file as UTF-8 with lossy decoding on errors. Used
+    so binary / non-UTF8 content never crashes `latest`/`show`."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        die(f"failed to read {path.name}: {exc}")
 
 
 def cmd_latest(project: Path, args: list[str]) -> None:
@@ -303,27 +380,60 @@ def cmd_latest(project: Path, args: list[str]) -> None:
     files = sorted(ckpt_dir.glob("*.md"))
     if not files:
         die("No checkpoints yet — run `checkpoint.py save` first")
-    print(files[-1].read_text(), end="")
+    print(_safe_read(files[-1]), end="")
+
+
+def _resolve_checkpoint(ckpt_dir: Path, query: str) -> Path:
+    """Resolve a user-supplied query to a single checkpoint file under
+    `ckpt_dir`. Refuses path traversal — the matched file's resolved path
+    must be inside the resolved ckpt_dir. The query is NOT treated as a
+    glob; glob metacharacters (`*`, `?`, `[`, `/`, backslash) are rejected."""
+    # Reject glob metacharacters and path separators entirely. The query is
+    # meant to be a literal filename fragment, not a glob pattern.
+    if not query or any(ch in query for ch in ("/", "\\", "*", "?", "[", "]", "\0")):
+        die(f"invalid query (contains path or glob metacharacter): {query}")
+    if ".." in query:
+        die(f"invalid query (path traversal): {query}")
+
+    resolved_dir = ckpt_dir.resolve()
+
+    # Literal prefix match first, then substring fallback — both scoped
+    # to files directly under ckpt_dir, no recursion, .md only.
+    candidates = [
+        p for p in ckpt_dir.iterdir()
+        if p.is_file() and p.suffix == ".md" and p.name.startswith(query)
+    ]
+    if not candidates:
+        candidates = [
+            p for p in ckpt_dir.iterdir()
+            if p.is_file() and p.suffix == ".md" and query in p.name
+        ]
+    if not candidates:
+        die(f"No checkpoint matching: {query}")
+    if len(candidates) > 1:
+        names = "\n".join(f"  {m.name}" for m in sorted(candidates))
+        die(f"Ambiguous query '{query}', matches:\n{names}")
+
+    match = candidates[0]
+    # Paranoia: verify the resolved match lives under ckpt_dir even after
+    # symlink resolution. Also ensures Python's Path doesn't surprise us.
+    try:
+        match.resolve().relative_to(resolved_dir)
+    except (ValueError, OSError):
+        die(f"refusing to open path outside checkpoints directory: {match}")
+    return match
 
 
 def cmd_show(project: Path, args: list[str]) -> None:
-    """show <filename-or-prefix>"""
+    """show <filename-or-substring>"""
     if not args:
-        die("Usage: checkpoint.py show <project-dir> <filename-or-prefix>")
+        die("Usage: checkpoint.py show <project-dir> <filename-or-substring>")
     query = args[0]
     ckpt_dir = project / ".autonomous" / "checkpoints"
     if not ckpt_dir.exists():
         die("No checkpoints directory yet")
-    matches = sorted(ckpt_dir.glob(f"{query}*"))
-    if not matches:
-        # Try substring match as fallback
-        matches = sorted(f for f in ckpt_dir.glob("*.md") if query in f.name)
-    if not matches:
-        die(f"No checkpoint matching: {query}")
-    if len(matches) > 1:
-        names = "\n".join(f"  {m.name}" for m in matches)
-        die(f"Ambiguous query '{query}', matches:\n{names}")
-    print(matches[0].read_text(), end="")
+    match = _resolve_checkpoint(ckpt_dir, query)
+    print(_safe_read(match), end="")
 
 
 def usage() -> None:

--- a/scripts/checkpoint.py
+++ b/scripts/checkpoint.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Session checkpoint snapshots for autonomous-skill.
+
+Dumps the current conductor state, sprint history, backlog summary, and git
+state into a human-readable markdown file at
+`.autonomous/checkpoints/<timestamp>-<slug>.md`. Useful for:
+
+- Context switching — come back next day, read the latest checkpoint
+- Sharing — send to a teammate who asks "what's the autonomous session doing?"
+- Review — before resuming, confirm sprints 1-3 match what you expected
+
+Does NOT auto-resume a session. This is a human-readable snapshot only.
+Each save is a separate file; history is retained. Delete manually if needed.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, NoReturn
+
+
+def die(message: str) -> NoReturn:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def slugify(text: str, max_len: int = 40) -> str:
+    text = re.sub(r"[^a-zA-Z0-9\s-]", "", text).strip().lower()
+    text = re.sub(r"\s+", "-", text)
+    return text[:max_len] or "checkpoint"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError, FileNotFoundError):
+        return {}
+
+
+def git(project: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+
+
+def gather_git_state(project: Path) -> dict[str, Any]:
+    if not (project / ".git").exists():
+        return {"is_git": False}
+    current_branch = git(project, "rev-parse", "--abbrev-ref", "HEAD")
+    last_commit = git(project, "log", "-1", "--oneline", "--no-decorate")
+    status_porcelain = git(project, "status", "--porcelain")
+    modified_count = len([line for line in status_porcelain.splitlines() if line.strip()])
+    return {
+        "is_git": True,
+        "current_branch": current_branch,
+        "last_commit": last_commit,
+        "modified_count": modified_count,
+    }
+
+
+def format_sprint(sprint: dict[str, Any]) -> str:
+    num = sprint.get("number", "?")
+    direction = sprint.get("direction", "(no direction)")
+    status = sprint.get("status", "unknown")
+    commits = sprint.get("commits", [])
+    commit_count = len(commits) if isinstance(commits, list) else 0
+    summary = sprint.get("summary", "").strip()
+
+    lines = [f"{num}. **{direction}** — {status} ({commit_count} commit{'s' if commit_count != 1 else ''})"]
+    if summary:
+        # Indent-quote the summary so markdown renders it nicely
+        for summary_line in summary.splitlines():
+            lines.append(f"   > {summary_line}")
+    return "\n".join(lines)
+
+
+def render_markdown(
+    project: Path,
+    state: dict[str, Any],
+    backlog: dict[str, Any],
+    git_state: dict[str, Any],
+    title: str,
+    saved_at: str,
+) -> str:
+    session_id = state.get("session_id", "(no session)")
+    mission = state.get("mission", "(no mission)")
+    phase = state.get("phase", "unknown")
+    sprints = state.get("sprints", [])
+    max_sprints = state.get("max_sprints", "?")
+    exploration = state.get("exploration", {})
+
+    total_commits = sum(
+        len(s.get("commits", [])) for s in sprints if isinstance(s.get("commits"), list)
+    )
+
+    open_items = [
+        item for item in backlog.get("items", []) if item.get("status") == "open"
+    ]
+    untriaged = sum(1 for item in open_items if not item.get("triaged", True))
+    next_item = None
+    if open_items:
+        open_items_sorted = sorted(
+            open_items,
+            key=lambda it: (it.get("priority", 3), it.get("created_at", "")),
+        )
+        next_item = open_items_sorted[0]
+
+    lines: list[str] = []
+
+    # YAML frontmatter — for parseability if we later want to diff checkpoints
+    lines.append("---")
+    lines.append(f"saved_at: {saved_at}")
+    lines.append(f"session_id: {session_id}")
+    lines.append(f"session_branch: {git_state.get('current_branch', '')}")
+    lines.append(f"phase: {phase}")
+    lines.append(f"sprint_count: {len(sprints)}")
+    lines.append(f"max_sprints: {max_sprints}")
+    lines.append(f"commit_count: {total_commits}")
+    lines.append(f"backlog_open: {len(open_items)}")
+    lines.append(f"title: {json.dumps(title)}")
+    lines.append("---")
+    lines.append("")
+
+    # Header
+    lines.append(f"# Checkpoint: {title}")
+    lines.append("")
+    lines.append(f"_Saved at {saved_at}_")
+    lines.append("")
+
+    # Session section
+    lines.append("## Session")
+    lines.append(f"- **Mission**: {mission}")
+    lines.append(f"- **Phase**: {phase}")
+    lines.append(f"- **Sprints**: {len(sprints)} / {max_sprints}")
+    lines.append(f"- **Commits**: {total_commits}")
+    lines.append(f"- **Session branch**: `{git_state.get('current_branch', 'unknown')}`")
+    lines.append("")
+
+    # Sprint history
+    lines.append("## Sprint history")
+    if not sprints:
+        lines.append("_No sprints yet._")
+    else:
+        for sprint in sprints:
+            lines.append(format_sprint(sprint))
+            lines.append("")
+
+    # Exploration dimensions (only if in exploring phase or any audited)
+    audited = [
+        (dim, info) for dim, info in exploration.items() if info.get("audited")
+    ]
+    unaudited = [
+        dim for dim, info in exploration.items() if not info.get("audited")
+    ]
+    if audited or phase == "exploring":
+        lines.append("## Exploration dimensions")
+        for dim, info in audited:
+            score = info.get("score", "?")
+            lines.append(f"- `{dim}`: {score}/10")
+        for dim in unaudited:
+            lines.append(f"- `{dim}`: not audited")
+        lines.append("")
+
+    # Backlog
+    lines.append("## Backlog")
+    lines.append(f"- **Open**: {len(open_items)} ({untriaged} untriaged)")
+    if next_item:
+        title_line = next_item.get("title", "")
+        priority = next_item.get("priority", 3)
+        lines.append(f"- **Next up**: {title_line} (P{priority})")
+    lines.append("")
+
+    # Git state
+    lines.append("## Git state")
+    if git_state.get("is_git"):
+        lines.append(f"- **Current branch**: `{git_state.get('current_branch', '?')}`")
+        last_commit = git_state.get("last_commit", "")
+        if last_commit:
+            lines.append(f"- **Last commit**: `{last_commit}`")
+        modified = git_state.get("modified_count", 0)
+        if modified > 0:
+            lines.append(f"- **Uncommitted changes**: {modified} file{'s' if modified != 1 else ''}")
+        else:
+            lines.append("- **Working tree**: clean")
+    else:
+        lines.append("_Not a git repo._")
+    lines.append("")
+
+    # Resume guidance
+    lines.append("## Resume guidance")
+    if sprints:
+        lines.append("To resume this session manually:")
+        lines.append("")
+        branch = git_state.get("current_branch", "")
+        # Find the session branch (auto/session-*) if we're on a sprint branch
+        session_branch = branch
+        if "-sprint-" in branch:
+            session_branch = branch.split("-sprint-")[0]
+        if session_branch.startswith("auto/session"):
+            lines.append(f"1. `git checkout {session_branch}`")
+        else:
+            lines.append(f"1. Ensure you're on the session branch")
+        lines.append("2. Inspect `.autonomous/conductor-state.json` to confirm phase and sprint count")
+        remaining = state.get("max_sprints", 0)
+        if isinstance(remaining, int):
+            remaining = max(0, remaining - len(sprints))
+        if remaining:
+            lines.append(f"3. Re-invoke `/autonomous {remaining}` to continue with remaining sprints")
+        else:
+            lines.append("3. Max sprints reached — start a fresh session if more work is needed")
+    else:
+        lines.append("No sprints completed yet. Re-invoke `/autonomous <direction>` to start.")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def cmd_save(project: Path, args: list[str]) -> None:
+    """save [--title <text>]"""
+    title = ""
+    i = 0
+    while i < len(args):
+        if args[i] == "--title":
+            if i + 1 >= len(args):
+                die("--title requires a value")
+            title = args[i + 1]
+            i += 2
+        else:
+            die(f"Unknown flag: {args[i]} (only --title is supported)")
+
+    state = read_json(project / ".autonomous" / "conductor-state.json")
+    backlog = read_json(project / ".autonomous" / "backlog.json")
+    git_state = gather_git_state(project)
+
+    # Auto-generate title if none provided
+    if not title:
+        sprints = state.get("sprints", [])
+        if sprints:
+            last = sprints[-1]
+            title = f"sprint {last.get('number', len(sprints))} — {last.get('status', 'unknown')}"
+        else:
+            title = "session-start"
+
+    saved_at = now_iso()
+    ts_filename = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    slug = slugify(title)
+    filename = f"{ts_filename}-{slug}.md"
+
+    ckpt_dir = project / ".autonomous" / "checkpoints"
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    target = ckpt_dir / filename
+
+    content = render_markdown(project, state, backlog, git_state, title, saved_at)
+    target.write_text(content)
+    print(str(target))
+
+
+def cmd_list(project: Path, args: list[str]) -> None:
+    """list — list checkpoints oldest→newest"""
+    ckpt_dir = project / ".autonomous" / "checkpoints"
+    if not ckpt_dir.exists():
+        return
+    files = sorted(ckpt_dir.glob("*.md"))
+    for f in files:
+        # Print: filename\ttitle (if parseable from frontmatter)
+        try:
+            head = f.read_text().splitlines()[:20]
+        except OSError:
+            head = []
+        title_val = ""
+        for line in head:
+            if line.startswith("title: "):
+                title_val = line[len("title: "):].strip().strip('"')
+                break
+        if title_val:
+            print(f"{f.name}\t{title_val}")
+        else:
+            print(f.name)
+
+
+def cmd_latest(project: Path, args: list[str]) -> None:
+    """latest — print the most recent checkpoint"""
+    ckpt_dir = project / ".autonomous" / "checkpoints"
+    if not ckpt_dir.exists():
+        die("No checkpoints directory yet")
+    files = sorted(ckpt_dir.glob("*.md"))
+    if not files:
+        die("No checkpoints yet — run `checkpoint.py save` first")
+    print(files[-1].read_text(), end="")
+
+
+def cmd_show(project: Path, args: list[str]) -> None:
+    """show <filename-or-prefix>"""
+    if not args:
+        die("Usage: checkpoint.py show <project-dir> <filename-or-prefix>")
+    query = args[0]
+    ckpt_dir = project / ".autonomous" / "checkpoints"
+    if not ckpt_dir.exists():
+        die("No checkpoints directory yet")
+    matches = sorted(ckpt_dir.glob(f"{query}*"))
+    if not matches:
+        # Try substring match as fallback
+        matches = sorted(f for f in ckpt_dir.glob("*.md") if query in f.name)
+    if not matches:
+        die(f"No checkpoint matching: {query}")
+    if len(matches) > 1:
+        names = "\n".join(f"  {m.name}" for m in matches)
+        die(f"Ambiguous query '{query}', matches:\n{names}")
+    print(matches[0].read_text(), end="")
+
+
+def usage() -> None:
+    print(
+        """Usage: checkpoint.py <command> <project-dir> [args...]
+
+Commands:
+  save <project> [--title <text>]   Write a new checkpoint, print its path
+  list <project>                    List checkpoints (filename + title)
+  latest <project>                  Print the most recent checkpoint
+  show <project> <filename-prefix>  Print a specific checkpoint
+
+Checkpoint files live at `<project>/.autonomous/checkpoints/`. Each is a
+self-contained markdown snapshot; history is retained.
+
+Examples:
+  python3 checkpoint.py save . --title "pre-refactor snapshot"
+  python3 checkpoint.py list .
+  python3 checkpoint.py latest .
+  python3 checkpoint.py show . 20260419
+""",
+        file=sys.stderr,
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) <= 1 or argv[1] in {"-h", "--help", "help"}:
+        usage()
+        return 0
+
+    cmd = argv[1]
+    project = Path(argv[2]) if len(argv) > 2 else Path(".")
+    args = argv[3:]
+
+    if cmd == "save":
+        cmd_save(project, args)
+    elif cmd == "list":
+        cmd_list(project, args)
+    elif cmd == "latest":
+        cmd_latest(project, args)
+    elif cmd == "show":
+        cmd_show(project, args)
+    else:
+        die(f"Unknown command: {cmd}. Use: save|list|latest|show")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/tests/test_checkpoint.sh
+++ b/tests/test_checkpoint.sh
@@ -69,7 +69,8 @@ assert_file_contains "$OUT" "add user model" "sprint direction in checkpoint"
 assert_file_contains "$OUT" "Schema + migrations landed" "sprint summary in checkpoint"
 assert_file_contains "$OUT" "1 / 10" "sprint count shown"
 assert_file_contains "$OUT" "2 commits" "commit count shown"
-assert_file_contains "$OUT" "phase: directed" "phase in frontmatter"
+# All YAML scalars are JSON-quoted now (frontmatter injection fix).
+assert_file_contains "$OUT" 'phase: "directed"' "phase in frontmatter (JSON-quoted)"
 assert_file_contains "$OUT" "sprint_count: 1" "sprint count in frontmatter"
 assert_file_contains "$OUT" "commit_count: 2" "commit count in frontmatter"
 
@@ -265,5 +266,125 @@ assert_contains "$BASE2" "checkpoint" "all-special title falls back to 'checkpoi
 # Title with unicode — survives, frontmatter escapes it
 OUT3=$(python3 "$CKPT" save "$T" --title "中文 checkpoint")
 assert_file_contains "$OUT3" "中文 checkpoint" "unicode title preserved in content"
+
+# ── 11. Adversarial regression (Codex review findings) ──────────────────
+
+echo ""
+echo "11. Adversarial regression (Codex findings)"
+
+# P1: `show` previously treated query as a glob, allowing path traversal.
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+python3 "$CKPT" save "$T" --title "legit" > /dev/null
+# Create a file outside the checkpoints dir we could try to read
+echo "SECRET" > "$T/.autonomous/secret.json"
+
+# Path traversal via ../
+if python3 "$CKPT" show "$T" "../secret.json" 2>/dev/null; then
+  fail "show ../secret.json should be rejected"
+else
+  ok "show rejects path traversal via ../"
+fi
+
+# Glob metacharacters must be rejected (query is not a glob anymore)
+if python3 "$CKPT" show "$T" "*" 2>/dev/null; then
+  fail "show with * (glob) should be rejected"
+else
+  ok "show rejects * metacharacter"
+fi
+
+if python3 "$CKPT" show "$T" "?" 2>/dev/null; then
+  fail "show with ? should be rejected"
+else
+  ok "show rejects ? metacharacter"
+fi
+
+if python3 "$CKPT" show "$T" "[abc]" 2>/dev/null; then
+  fail "show with character class should be rejected"
+else
+  ok "show rejects character class"
+fi
+
+if python3 "$CKPT" show "$T" "dir/file" 2>/dev/null; then
+  fail "show with / should be rejected"
+else
+  ok "show rejects path separator"
+fi
+
+# P1: Frontmatter injection via session_id/phase containing YAML-hostile chars
+T=$(make_project)
+mkdir -p "$T/.autonomous"
+# conductor-state with colon, newline, and # in session_id → must not break YAML
+cat > "$T/.autonomous/conductor-state.json" <<'EOF'
+{"session_id": "malicious: injected\nkey: hijacked # comment", "phase": "[{broken", "mission": "ok", "sprints": [], "max_sprints": 5, "exploration": {}}
+EOF
+OUT=$(python3 "$CKPT" save "$T" --title "injection-test")
+# The injected keys MUST NOT appear as top-level YAML keys
+if grep -q "^key: hijacked" "$OUT"; then
+  fail "YAML injection succeeded (new top-level key created)"
+else
+  ok "YAML frontmatter resists : + newline injection"
+fi
+# The weird phase value must be quoted as a string, not interpreted as a list
+assert_file_contains "$OUT" 'phase: "\[{broken"' "hostile phase value is JSON-quoted"
+
+# P1: read_json type safety — non-dict conductor-state.json doesn't crash
+T=$(make_project)
+mkdir -p "$T/.autonomous"
+echo '["this","is","a","list","not","a","dict"]' > "$T/.autonomous/conductor-state.json"
+OUT=$(python3 "$CKPT" save "$T" 2>&1) && RC=0 || RC=$?
+assert_eq "$RC" "0" "non-dict state.json doesn't crash save"
+assert_file_exists "$OUT" "checkpoint written despite bad state shape"
+
+# sprints field as a dict (not list) — previous code iterated and crashed
+T=$(make_project)
+mkdir -p "$T/.autonomous"
+cat > "$T/.autonomous/conductor-state.json" <<'EOF'
+{"session_id":"s","mission":"m","phase":"directed","sprints":{"wrong":"shape"},"exploration":"also wrong"}
+EOF
+OUT=$(python3 "$CKPT" save "$T" 2>&1) && RC=0 || RC=$?
+assert_eq "$RC" "0" "wrong-shape sprints doesn't crash save"
+
+# P2: Same-second same-title saves don't silently overwrite
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+OUT1=$(python3 "$CKPT" save "$T" --title "same-name")
+OUT2=$(python3 "$CKPT" save "$T" --title "same-name")
+[ "$OUT1" != "$OUT2" ] && ok "same-second same-title saves produce different files" || fail "silent overwrite"
+# Both files should exist
+[ -f "$OUT1" ] && [ -f "$OUT2" ] && ok "both same-name checkpoints retained" || fail "one checkpoint lost"
+# Second filename should have -1 suffix
+BASE2=$(basename "$OUT2" .md)
+assert_contains "$BASE2" "same-name-1" "collision resolved with numeric suffix"
+
+# P2: list title extraction decodes JSON escapes
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+python3 "$CKPT" save "$T" --title '中文 title with spaces' > /dev/null
+LIST=$(python3 "$CKPT" list "$T")
+# Title should display the actual unicode, not the \uXXXX escape
+assert_contains "$LIST" "中文 title with spaces" "list shows unicode title verbatim (not JSON-escaped)"
+# Shouldn't show raw escapes
+if echo "$LIST" | grep -q '\\u4e2d'; then
+  fail "list shows raw \\uXXXX escape (JSON decode failed)"
+else
+  ok "list did not leak \\uXXXX escape"
+fi
+
+# P2: Non-UTF8 checkpoint file doesn't crash latest/show
+T=$(make_project)
+mkdir -p "$T/.autonomous/checkpoints"
+printf '\xff\xfe\x00\x00garbage' > "$T/.autonomous/checkpoints/20260419-000001-binary.md"
+LATEST=$(python3 "$CKPT" latest "$T" 2>&1) && RC=0 || RC=$?
+assert_eq "$RC" "0" "latest survives non-UTF8 file"
+SHOWN=$(python3 "$CKPT" show "$T" "binary" 2>&1) && RC=0 || RC=$?
+assert_eq "$RC" "0" "show survives non-UTF8 file"
+
+# Malformed conductor-state.json (valid JSON, missing fields) doesn't crash
+T=$(make_project)
+mkdir -p "$T/.autonomous"
+echo 'null' > "$T/.autonomous/conductor-state.json"
+OUT=$(python3 "$CKPT" save "$T" 2>&1) && RC=0 || RC=$?
+assert_eq "$RC" "0" "null top-level state doesn't crash"
 
 print_results

--- a/tests/test_checkpoint.sh
+++ b/tests/test_checkpoint.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CKPT="$SCRIPT_DIR/../scripts/checkpoint.py"
+CONDUCTOR="$SCRIPT_DIR/../scripts/conductor-state.py"
+BACKLOG="$SCRIPT_DIR/../scripts/backlog.py"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_checkpoint.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Minimal git project setup for tests that need git state
+make_project() {
+  local p
+  p=$(new_tmp)
+  (cd "$p" && git init -q && git -c user.name=test -c user.email=t@t.com commit --allow-empty -q -m "init") >/dev/null
+  echo "$p"
+}
+
+# ── 1. Help + basic CLI ───────────────────────────────────────────────────
+
+echo ""
+echo "1. Help + basic CLI"
+
+HELP=$(python3 "$CKPT" --help 2>&1)
+assert_contains "$HELP" "Usage: checkpoint.py" "--help shows usage"
+assert_contains "$HELP" "save" "--help documents save"
+assert_contains "$HELP" "list" "--help documents list"
+assert_contains "$HELP" "latest" "--help documents latest"
+assert_contains "$HELP" "show" "--help documents show"
+
+if python3 "$CKPT" unknowncmd "$(new_tmp)" 2>/dev/null; then
+  fail "unknown command should fail"
+else
+  ok "unknown command rejected"
+fi
+
+# ── 2. Save with no state (empty project) ────────────────────────────────
+
+echo ""
+echo "2. Save with no state"
+
+T=$(make_project)
+OUT=$(python3 "$CKPT" save "$T")
+assert_file_exists "$OUT" "checkpoint file created even without conductor state"
+assert_file_contains "$OUT" "session-start" "no-state checkpoint uses 'session-start' title"
+assert_file_contains "$OUT" "(no session)" "no-state shows placeholder session"
+assert_file_contains "$OUT" "(no mission)" "no-state shows placeholder mission"
+assert_file_contains "$OUT" "No sprints yet" "no-state shows no sprints placeholder"
+assert_file_contains "$OUT" "^---$" "file has YAML frontmatter"
+
+# ── 3. Save with conductor state ─────────────────────────────────────────
+
+echo ""
+echo "3. Save with conductor state"
+
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "build REST API" 10 > /dev/null
+python3 "$CONDUCTOR" sprint-start "$T" "add user model" > /dev/null
+python3 "$CONDUCTOR" sprint-end "$T" complete "Schema + migrations landed" '["abc001","abc002"]' true > /dev/null
+
+OUT=$(python3 "$CKPT" save "$T")
+assert_file_contains "$OUT" "build REST API" "mission in checkpoint"
+assert_file_contains "$OUT" "add user model" "sprint direction in checkpoint"
+assert_file_contains "$OUT" "Schema + migrations landed" "sprint summary in checkpoint"
+assert_file_contains "$OUT" "1 / 10" "sprint count shown"
+assert_file_contains "$OUT" "2 commits" "commit count shown"
+assert_file_contains "$OUT" "phase: directed" "phase in frontmatter"
+assert_file_contains "$OUT" "sprint_count: 1" "sprint count in frontmatter"
+assert_file_contains "$OUT" "commit_count: 2" "commit count in frontmatter"
+
+# Auto-generated title based on latest sprint
+assert_file_contains "$OUT" "sprint 1" "title mentions latest sprint"
+
+# ── 4. Save with --title ─────────────────────────────────────────────────
+
+echo ""
+echo "4. Save with --title"
+
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "mission" 5 > /dev/null
+OUT=$(python3 "$CKPT" save "$T" --title "pre-refactor snapshot")
+assert_file_contains "$OUT" "pre-refactor snapshot" "custom title appears in checkpoint"
+BASENAME=$(basename "$OUT")
+assert_contains "$BASENAME" "pre-refactor-snapshot" "filename includes slugged title"
+
+# Title validation
+if python3 "$CKPT" save "$T" --title 2>/dev/null; then
+  fail "--title without value should fail"
+else
+  ok "--title without value rejected"
+fi
+
+if python3 "$CKPT" save "$T" --unknownflag x 2>/dev/null; then
+  fail "unknown flag should fail"
+else
+  ok "unknown flag rejected"
+fi
+
+# ── 5. Multiple saves → separate files ───────────────────────────────────
+
+echo ""
+echo "5. Multiple saves"
+
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+OUT1=$(python3 "$CKPT" save "$T" --title "first")
+sleep 1  # ensure timestamp filenames differ (second-granularity)
+OUT2=$(python3 "$CKPT" save "$T" --title "second")
+OUT3=$(python3 "$CKPT" save "$T" --title "third-in-same-second")
+
+[ "$OUT1" != "$OUT2" ] && ok "different timestamps produce different files" || fail "filenames collided"
+
+LIST=$(python3 "$CKPT" list "$T")
+LINE_COUNT=$(echo "$LIST" | wc -l | tr -d ' ')
+assert_ge "$LINE_COUNT" "3" "list shows all 3 saves"
+assert_contains "$LIST" "first" "list shows first title"
+assert_contains "$LIST" "second" "list shows second title"
+assert_contains "$LIST" "third" "list shows third title"
+
+# Latest returns the most recent
+LATEST=$(python3 "$CKPT" latest "$T")
+assert_contains "$LATEST" "third" "latest shows most recent checkpoint"
+
+# ── 6. Show by prefix ─────────────────────────────────────────────────────
+
+echo ""
+echo "6. Show by prefix"
+
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+OUT=$(python3 "$CKPT" save "$T" --title "unique-marker-xyz")
+BASENAME=$(basename "$OUT" .md)
+
+SHOWN=$(python3 "$CKPT" show "$T" "$BASENAME")
+assert_contains "$SHOWN" "unique-marker-xyz" "show by exact prefix returns content"
+
+# Substring fallback
+SHOWN2=$(python3 "$CKPT" show "$T" "unique-marker")
+assert_contains "$SHOWN2" "unique-marker-xyz" "show by substring fallback works"
+
+# Not found
+if python3 "$CKPT" show "$T" "nonexistent-xyz-qqq" 2>/dev/null; then
+  fail "show of missing checkpoint should fail"
+else
+  ok "show of missing checkpoint rejected"
+fi
+
+# No-arg show fails
+if python3 "$CKPT" show "$T" 2>/dev/null; then
+  fail "show without query should fail"
+else
+  ok "show without query rejected"
+fi
+
+# Ambiguous show fails when 2+ match
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+python3 "$CKPT" save "$T" --title "ambiguous-one" > /dev/null
+sleep 1
+python3 "$CKPT" save "$T" --title "ambiguous-two" > /dev/null
+if python3 "$CKPT" show "$T" "ambiguous" 2>/dev/null; then
+  fail "ambiguous show should fail"
+else
+  ok "ambiguous show rejected"
+fi
+
+# ── 7. Latest/list when empty ────────────────────────────────────────────
+
+echo ""
+echo "7. Empty-checkpoint error paths"
+
+T=$(make_project)
+if python3 "$CKPT" latest "$T" 2>/dev/null; then
+  fail "latest on empty should fail"
+else
+  ok "latest on empty rejected"
+fi
+
+LIST_EMPTY=$(python3 "$CKPT" list "$T" 2>&1)
+assert_eq "$LIST_EMPTY" "" "list on empty project produces no output"
+
+if python3 "$CKPT" show "$T" anything 2>/dev/null; then
+  fail "show on empty should fail"
+else
+  ok "show on empty rejected"
+fi
+
+# ── 8. Backlog + exploration summary ─────────────────────────────────────
+
+echo ""
+echo "8. Backlog + exploration summary"
+
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+python3 "$BACKLOG" init "$T" > /dev/null
+python3 "$BACKLOG" add "$T" "Rate-limit login endpoint" "detail" conductor 2 > /dev/null
+python3 "$BACKLOG" add "$T" "Audit secrets" "detail2" worker 4 > /dev/null
+
+OUT=$(python3 "$CKPT" save "$T")
+assert_file_contains "$OUT" "Open\**: 2" "backlog open count shown"
+assert_file_contains "$OUT" "Rate-limit login endpoint" "next-up item shown (highest priority)"
+assert_file_contains "$OUT" "P2" "next-up priority shown"
+
+# Exploration dimensions shown when in exploring phase
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 2 > /dev/null
+python3 "$CONDUCTOR" sprint-start "$T" "d" > /dev/null
+python3 "$CONDUCTOR" sprint-end "$T" complete "done" '[]' false > /dev/null
+# Now in exploring phase (max_directed=1 for 2 sprints)
+python3 "$CONDUCTOR" explore-score "$T" security 7 > /dev/null
+
+OUT=$(python3 "$CKPT" save "$T")
+assert_file_contains "$OUT" "Exploration dimensions" "exploration section shown when exploring"
+assert_file_contains "$OUT" "security.*7" "audited dimension score shown"
+assert_file_contains "$OUT" "test_coverage.*not audited" "unaudited dimensions listed"
+
+# ── 9. Git state ─────────────────────────────────────────────────────────
+
+echo ""
+echo "9. Git state reporting"
+
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+# Add an untracked file
+echo "modified" > "$T/newfile.txt"
+
+OUT=$(python3 "$CKPT" save "$T")
+assert_file_contains "$OUT" "Current branch" "current branch reported"
+assert_file_contains "$OUT" "init" "last commit reported"
+assert_file_contains "$OUT" "Uncommitted changes" "uncommitted files reported"
+
+# Non-git directory
+T2=$(new_tmp)
+OUT2=$(python3 "$CKPT" save "$T2")
+assert_file_contains "$OUT2" "Not a git repo" "non-git project handled gracefully"
+
+# ── 10. Slugify / filename safety ────────────────────────────────────────
+
+echo ""
+echo "10. Slugify + filename safety"
+
+T=$(make_project)
+python3 "$CONDUCTOR" init "$T" "m" 5 > /dev/null
+
+# Title with special chars — filename should stay safe
+OUT=$(python3 "$CKPT" save "$T" --title 'weird/title with "quotes" and <brackets>!')
+BASE=$(basename "$OUT")
+# Filename should only contain safe chars
+if echo "$BASE" | grep -qE '[/"<>!]'; then
+  fail "filename contains unsafe chars: $BASE"
+else
+  ok "filename slugged to safe chars"
+fi
+
+# Title with only special chars → fallback to "checkpoint"
+OUT2=$(python3 "$CKPT" save "$T" --title '!!!@@@###')
+BASE2=$(basename "$OUT2")
+assert_contains "$BASE2" "checkpoint" "all-special title falls back to 'checkpoint'"
+
+# Title with unicode — survives, frontmatter escapes it
+OUT3=$(python3 "$CKPT" save "$T" --title "中文 checkpoint")
+assert_file_contains "$OUT3" "中文 checkpoint" "unicode title preserved in content"
+
+print_results


### PR DESCRIPTION
## Summary

Adds `scripts/checkpoint.py` — a CLI for writing markdown snapshots of the current autonomous session to `.autonomous/checkpoints/<ts>-<slug>.md`. Pure read-only snapshot; no auto-resume yet.

Inspired by gstack's `/checkpoint` skill.

## Commands

```bash
python3 checkpoint.py save <project> [--title <text>]   # write, print path
python3 checkpoint.py list <project>                    # filename + title
python3 checkpoint.py latest <project>                  # print most recent
python3 checkpoint.py show <project> <prefix-or-substr> # print a specific one
```

## What's captured

- **Frontmatter** — `saved_at`, `session_id`, `session_branch`, `phase`, `sprint_count`, `commit_count`, `backlog_open`, `title` (for future cross-checkpoint diffing)
- **Session** — mission, phase, sprints completed / max, total commits, session branch
- **Sprint history** — each sprint's direction, status, commit count, summary quoted inline
- **Exploration** — audited dimension scores + unaudited list (shown in exploring phase or if any dim is scored)
- **Backlog** — open count, untriaged count, highest-priority next-up item
- **Git state** — current branch, last commit, uncommitted file count
- **Resume guidance** — shell commands to get back on the session branch

## Use cases

1. **Context switching** — close laptop, come back next day: `checkpoint latest .` shows where you were
2. **Sharing** — paste a checkpoint into Slack/email to a teammate
3. **Review** — before resuming, confirm sprints 1-3 landed what you expected
4. **Before a risky step** — checkpoint pre-refactor so you can inspect state later

## Design choices

| Decision | Why |
|---|---|
| Append-only history (no rotation) | Users delete manually; JSONL/markdown compresses cheaply; `/autonomous` session often runs for hours — 5-20 checkpoints is a reasonable manual ceiling |
| Human-readable markdown + YAML frontmatter | Readable in any editor; parseable later if we want diffs |
| NOT auto-resume | Programmatic reload into a running conductor is complex (tmux state, PID locks, branch state). Defer until there's demand. |
| Title auto-generation from latest sprint | Most checkpoints correspond to a sprint boundary — "sprint 3 — complete" is useful without user input |
| `show` does prefix then substring | Users type timestamps or keywords; both should work |
| Rejects ambiguous substring matches | Avoid silently showing wrong checkpoint |

## Test plan

- [x] `bash tests/test_checkpoint.sh` — 52/52 passing
- [x] `python3 -m compileall scripts` clean
- [x] All other suites unaffected (test_loop's 8 pre-existing failures still match main)
- [x] Empty-state (no conductor-state.json yet) produces a valid checkpoint with placeholders
- [x] Non-git projects produce a valid checkpoint
- [x] Special chars in `--title` slugify safely; unicode preserved in content