### PR TITLE
feat: per-sprint git worktrees (V1 — serial, isolation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to autonomous-skill are documented here.
 ## [Unreleased]
 
 ### Added
-- `scripts/checkpoint.py` — human-readable session snapshots. `save`/`list`/`latest`/`show` commands write markdown files (with YAML frontmatter) to `.autonomous/checkpoints/<ts>-<slug>.md`. Captures mission, phase, sprint history, exploration dimensions, backlog summary, git state, and resume guidance. Rejects path-traversal and glob-injection in `show`; all YAML scalars are JSON-quoted to resist frontmatter injection; `read_json` enforces dict shape.
-- `tests/test_checkpoint.sh` — 70 tests covering save/list/latest/show flows, same-second collision handling, path-traversal rejection, YAML injection resistance, type-unsafe JSON states, non-UTF8 checkpoints, unicode titles.
+- `scripts/worktree.py` — per-sprint git worktree manager. Creates `.worktrees/sprint-N/` on a dedicated sprint branch, symlinks `.autonomous/` back to the main tree so coordination files stay single-sourced. Commands: `create`, `remove`, `list`, `ensure-gitignore`, `prune`, `path`. Refuses symlinked `.worktrees/` or `.autonomous/` to prevent repo escape; validates branch names via `git check-ref-format`; requires `is_git_repo` before remove.
+- `tests/test_worktree.sh` — 65 tests covering CRUD, validation, symlink escape refusal, unregistered-directory remove guard, branch name validation, `.autonomous` symlink write-through, and multi-sprint coexistence.
+
+### Changed
+- `autonomous/SKILL.md` Dispatch phase — when `AUTONOMOUS_SPRINT_WORKTREES=1` is set, each sprint runs in its own worktree instead of flipping the main tree onto the sprint branch. Default remains OFF (opt-in). Merge runs first (with `--keep-branch`), then worktree removal, then branch delete — if merge conflicts, worktree and branch are preserved for forensics.
+- `scripts/merge-sprint.py` — adds `--keep-branch` flag (skip final `git branch -D`, worktree mode deletes the branch separately after worktree removal). Merge failures now return 1 with the merge aborted cleanly instead of raising.
 
 ## [0.6.0] — 2026-04-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/monitor-worker.py` — Poll comms.json + tmux/process liveness
 - `scripts/evaluate-sprint.py` — Read summary JSON, update conductor state
 - `scripts/merge-sprint.py` — Merge or discard sprint branch
+- `scripts/worktree.py` — Per-sprint git worktree manager (opt-in via `AUTONOMOUS_SPRINT_WORKTREES=1`): creates `.worktrees/sprint-N/` with symlinked `.autonomous/`, removes on success
 - `scripts/write-summary.py` — Generate sprint-summary.json
 - `scripts/conductor-state.py` — Conductor state management (atomic writes, PID lock, phase transitions; emits timeline events)
 - `scripts/timeline.py` — Append-only JSONL session event log at `.autonomous/timeline.jsonl` (session-start, sprint-start, sprint-end, phase-transition, session-end)
@@ -155,7 +156,7 @@ then set `{"template":"<name>"}` in `skill-config.json` (or the project override
 
 ## Testing
 
-585 tests across 11 suites, all pure bash:
+650 tests across 12 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -169,6 +170,7 @@ bash tests/test_eval_output.sh  # 35 tests: eval-safe output, shell quoting, tmu
 bash tests/test_timeline.sh     # 63 tests: append-only JSONL log, filters, conductor integration, phase-transition emission, non-raising emit, bounded tail
 bash tests/test_careful_hook.sh # 97 tests: PreToolUse hook pattern matching, adversarial bypasses, dispatch integration, window_name validation
 bash tests/test_checkpoint.sh   # 70 tests: save/list/latest/show, path-traversal rejection, YAML injection resistance, type-unsafe JSON, non-UTF8
+bash tests/test_worktree.sh     # 65 tests: per-sprint worktree CRUD, symlink escape refusal, branch validation, registered-worktree guard, merge-sprint --keep-branch
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,23 @@ Each checkpoint is a markdown file at `.autonomous/checkpoints/<ts>-<slug>.md` c
 
 Useful for context switching ("where was I yesterday?"), sharing session state with a teammate, or reviewing sprint output before resuming.
 
+### Sprint worktrees (opt-in)
+
+Set `AUTONOMOUS_SPRINT_WORKTREES=1` to run each sprint in its own git worktree under `.worktrees/sprint-N/`:
+
+```bash
+AUTONOMOUS_SPRINT_WORKTREES=1 /autonomous 5 build REST API
+```
+
+- Main tree stays on the session branch the whole time — no `git checkout -b` churn
+- Each sprint works on its own branch in its own directory, fully file-isolated
+- `.autonomous/` is symlinked from each worktree back to the main tree, so comms, state, summaries, and backlog all go through one source of truth
+- `.worktrees/` is auto-added to `.gitignore` on first sprint
+- On sprint completion: merge runs first (with `--keep-branch`), then the worktree is removed, then the branch is deleted. If merge conflicts, worktree and branch are preserved for forensic inspection.
+- `.worktrees/` or `.autonomous/` pre-existing as symlinks are refused (repo-escape prevention).
+
+V1 is serial-only — one sprint at a time. Parallel sprint dispatch is deferred to a future PR.
+
 
 ## Configuration
 

--- a/autonomous/SKILL.md
+++ b/autonomous/SKILL.md
@@ -221,15 +221,24 @@ eval "$(python3 "$SCRIPT_DIR/scripts/evaluate-sprint.py" "$(pwd)" "$SCRIPT_DIR" 
 If the sprint master reported "direction_complete: true" but git shows no
 commits, override to "false".
 
-**Merge or discard the sprint branch.** In worktree mode, the worktree must be
-removed before `merge-sprint.py` runs — `git branch -D` refuses to delete a
-branch checked out in a worktree:
+**Merge or discard the sprint branch.** In worktree mode we flip the order:
+merge first (with `--keep-branch` so the branch survives), then remove the
+worktree, then delete the branch. This preserves forensic state on merge
+conflicts — the worktree stays for inspection instead of being wiped before
+we know whether the merge succeeded.
 
 ```bash
 if [ "${AUTONOMOUS_SPRINT_WORKTREES:-0}" = "1" ]; then
-  python3 "$SCRIPT_DIR/scripts/worktree.py" remove "$(pwd)" "$SPRINT_NUM" || true
+  if python3 "$SCRIPT_DIR/scripts/merge-sprint.py" --keep-branch \
+       "$SESSION_BRANCH" "$SPRINT_BRANCH" "$SPRINT_NUM" "$STATUS" "$SUMMARY"; then
+    python3 "$SCRIPT_DIR/scripts/worktree.py" remove "$(pwd)" "$SPRINT_NUM" || true
+    git branch -D "$SPRINT_BRANCH" 2>/dev/null || true
+  else
+    echo "Merge of sprint $SPRINT_NUM failed (conflicts). Worktree preserved at .worktrees/sprint-$SPRINT_NUM for inspection; branch $SPRINT_BRANCH kept. Conductor should treat this as a blocked sprint."
+  fi
+else
+  python3 "$SCRIPT_DIR/scripts/merge-sprint.py" "$SESSION_BRANCH" "$SPRINT_BRANCH" "$SPRINT_NUM" "$STATUS" "$SUMMARY"
 fi
-python3 "$SCRIPT_DIR/scripts/merge-sprint.py" "$SESSION_BRANCH" "$SPRINT_BRANCH" "$SPRINT_NUM" "$STATUS" "$SUMMARY"
 ```
 
 **If exploring**: Score the dimension after the sprint:

--- a/autonomous/SKILL.md
+++ b/autonomous/SKILL.md
@@ -180,14 +180,25 @@ python3 "$SCRIPT_DIR/scripts/backlog.py" update "$(pwd)" "<item-id>" priority 2
 python3 "$SCRIPT_DIR/scripts/conductor-state.py" sprint-start "$(pwd)" "$SPRINT_DIRECTION"
 SPRINT_NUM=$(python3 -c "import json; d=json.load(open('.autonomous/conductor-state.json')); print(len(d['sprints']))")
 SPRINT_BRANCH="${SESSION_BRANCH}-sprint-${SPRINT_NUM}"
-git checkout -b "$SPRINT_BRANCH"
 
-# Build sprint prompt (inlines SPRINT.md + params) and dispatch
+# Two modes — worktree-per-sprint (opt-in) or inline branch switching (default).
+# Worktree mode keeps the main tree on the session branch and runs each sprint
+# in its own .worktrees/sprint-N/ directory, giving file-level isolation
+# between consecutive sprints. Enable with AUTONOMOUS_SPRINT_WORKTREES=1.
+if [ "${AUTONOMOUS_SPRINT_WORKTREES:-0}" = "1" ]; then
+  python3 "$SCRIPT_DIR/scripts/worktree.py" ensure-gitignore "$(pwd)" >/dev/null || true
+  SPRINT_DIR=$(python3 "$SCRIPT_DIR/scripts/worktree.py" create "$(pwd)" "$SPRINT_NUM" "$SPRINT_BRANCH")
+else
+  git checkout -b "$SPRINT_BRANCH"
+  SPRINT_DIR="$(pwd)"
+fi
+
+# Build sprint prompt (always in the main tree's .autonomous/) and dispatch into $SPRINT_DIR.
 PREV_SUMMARY=""
 [ -f ".autonomous/sprint-$((SPRINT_NUM-1))-summary.json" ] && \
   PREV_SUMMARY=$(cat ".autonomous/sprint-$((SPRINT_NUM-1))-summary.json")
 python3 "$SCRIPT_DIR/scripts/build-sprint-prompt.py" "$(pwd)" "$SCRIPT_DIR" "$SPRINT_NUM" "$SPRINT_DIRECTION" "$PREV_SUMMARY"
-python3 "$SCRIPT_DIR/scripts/dispatch.py" "$(pwd)" .autonomous/sprint-prompt.md "sprint-$SPRINT_NUM"
+python3 "$SCRIPT_DIR/scripts/dispatch.py" "$SPRINT_DIR" .autonomous/sprint-prompt.md "sprint-$SPRINT_NUM"
 ```
 
 ### 3. Monitor — Wait for Sprint Completion
@@ -210,9 +221,14 @@ eval "$(python3 "$SCRIPT_DIR/scripts/evaluate-sprint.py" "$(pwd)" "$SCRIPT_DIR" 
 If the sprint master reported "direction_complete: true" but git shows no
 commits, override to "false".
 
-**Merge or discard the sprint branch:**
+**Merge or discard the sprint branch.** In worktree mode, the worktree must be
+removed before `merge-sprint.py` runs — `git branch -D` refuses to delete a
+branch checked out in a worktree:
 
 ```bash
+if [ "${AUTONOMOUS_SPRINT_WORKTREES:-0}" = "1" ]; then
+  python3 "$SCRIPT_DIR/scripts/worktree.py" remove "$(pwd)" "$SPRINT_NUM" || true
+fi
 python3 "$SCRIPT_DIR/scripts/merge-sprint.py" "$SESSION_BRANCH" "$SPRINT_BRANCH" "$SPRINT_NUM" "$STATUS" "$SUMMARY"
 ```
 

--- a/scripts/merge-sprint.py
+++ b/scripts/merge-sprint.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Merge or discard sprint branches."""
+"""Merge or discard sprint branches.
+
+By default, the sprint branch is deleted after merge/discard. In worktree
+mode (--keep-branch), the conductor is expected to delete the branch
+*after* the worktree is removed, since `git branch -D` refuses to delete
+a branch that's checked out in any worktree.
+
+Exit codes:
+  0 — merged, discarded (no commits), or successfully bailed without changes
+  1 — merge conflict or other git failure. In worktree mode, the worktree
+      should be preserved for inspection.
+"""
 from __future__ import annotations
 
 import argparse
@@ -24,6 +35,12 @@ def main(argv: list[str]) -> int:
     parser.add_argument("status")
     parser.add_argument("summary", nargs="?", default="")
     parser.add_argument("--project-dir", default=None, help="Project directory (defaults to CWD)")
+    parser.add_argument(
+        "--keep-branch",
+        action="store_true",
+        help="Skip `git branch -D` at the end. Use in worktree mode where "
+        "the worktree must be removed first before git will let us delete the branch.",
+    )
     args = parser.parse_args(argv[1:])
 
     cwd = args.project_dir
@@ -42,7 +59,9 @@ def main(argv: list[str]) -> int:
         )
         if commits:
             message = args.summary or f"Sprint {args.sprint_num}"
-            run(
+            # Use check=False here so merge conflicts don't raise — we return
+            # 1 so the conductor can preserve the worktree for inspection.
+            result = subprocess.run(
                 [
                     "git",
                     "merge",
@@ -52,14 +71,26 @@ def main(argv: list[str]) -> int:
                     f"sprint {args.sprint_num}: {message}",
                 ],
                 cwd=cwd,
+                check=False,
             )
+            if result.returncode != 0:
+                print(
+                    f"ERROR: merge of sprint {args.sprint_num} into "
+                    f"{args.session_branch} failed (conflicts or git error). "
+                    f"Sprint branch preserved.",
+                    file=sys.stderr,
+                )
+                # Abort the in-progress merge so main tree is left clean.
+                subprocess.run(["git", "merge", "--abort"], cwd=cwd, check=False)
+                return 1
             print(f"Sprint {args.sprint_num} merged into {args.session_branch}")
         else:
             print(f"Sprint {args.sprint_num} had no commits, skipping merge")
     else:
         print(f"Sprint {args.sprint_num} discarded ({args.status})")
 
-    subprocess.run(["git", "branch", "-D", args.sprint_branch], cwd=cwd, check=False)
+    if not args.keep_branch:
+        subprocess.run(["git", "branch", "-D", args.sprint_branch], cwd=cwd, check=False)
     return 0
 
 

--- a/scripts/worktree.py
+++ b/scripts/worktree.py
@@ -14,10 +14,20 @@ via `$(pwd)/.autonomous/` as before — the symlink is transparent.
 
 V1 scope: serial sprints, worktree per sprint, isolation only. Parallel
 dispatch + file-overlap guards are deferred to V2.
+
+Safety invariants (enforced, see codex review on PR #55):
+- `.worktrees/` and `.autonomous/` in the project root must be real
+  directories, not symlinks. A symlink would let `git worktree add` and
+  the symlink target resolution escape the project.
+- `remove` always validates the target is a real git worktree under the
+  project's `.worktrees/`. Never delegates to `rmtree` against arbitrary paths.
+- Branch name must pass `git check-ref-format --branch`.
+- Sprint number must be a positive integer (not 0, not negative).
 """
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -35,6 +45,43 @@ def worktree_root(project_root: Path) -> Path:
 
 def sprint_worktree_path(project_root: Path, sprint_num: int) -> Path:
     return worktree_root(project_root) / f"sprint-{sprint_num}"
+
+
+def _assert_real_dir(path: Path, label: str) -> None:
+    """Refuse to proceed if `path` exists and is a symlink (not a real dir).
+    Prevents an attacker or accident from making `.worktrees/` or
+    `.autonomous/` point outside the repo so subsequent file ops escape."""
+    if path.exists() and path.is_symlink():
+        die(f"{label} is a symlink — refusing to operate ({path} -> {os.readlink(path)})")
+
+
+def _validate_sprint_num(raw: str) -> int:
+    """Parse and validate sprint number. Must be a positive integer so
+    path composition (`sprint-{n}`) can't produce oddities like `sprint--1`
+    or `sprint-0` that collide with manual work."""
+    try:
+        n = int(raw)
+    except ValueError:
+        die(f"sprint-num must be integer, got: {raw}")
+    if n < 1:
+        die(f"sprint-num must be >= 1, got: {n}")
+    return n
+
+
+def _validate_branch_name(name: str, project_root: Path) -> None:
+    """Ensure branch name is safe for git. Uses git's own validator to
+    reject control chars, leading `-`, whitespace, reserved sequences, etc."""
+    if not name.strip():
+        die("branch-name is required")
+    result = subprocess.run(
+        ["git", "check-ref-format", "--branch", name],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        die(f"invalid branch name '{name}': {result.stderr.strip() or 'rejected by git check-ref-format'}")
 
 
 def git(args: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
@@ -64,24 +111,26 @@ def cmd_create(project_root: Path, args: list[str]) -> None:
     """create <sprint-num> <branch-name>"""
     if len(args) < 2:
         die("Usage: worktree.py create <project-root> <sprint-num> <branch-name>")
-    try:
-        sprint_num = int(args[0])
-    except ValueError:
-        die(f"sprint-num must be integer, got: {args[0]}")
+    sprint_num = _validate_sprint_num(args[0])
     branch_name = args[1]
-    if not branch_name.strip():
-        die("branch-name is required")
 
     if not is_git_repo(project_root):
         die(f"not a git repo: {project_root}")
+    _validate_branch_name(branch_name, project_root)
+
+    # Refuse to operate if .worktrees/ or .autonomous/ are pre-existing
+    # symlinks — they'd escape the repo via git's followed-path writes.
+    worktrees_dir = worktree_root(project_root)
+    _assert_real_dir(worktrees_dir, ".worktrees")
+    _assert_real_dir(project_root / ".autonomous", ".autonomous")
 
     wt_path = sprint_worktree_path(project_root, sprint_num)
-    worktree_root(project_root).mkdir(exist_ok=True)
+    worktrees_dir.mkdir(exist_ok=True)
 
     # Prune stale entries before creating a new one. Harmless if nothing is stale.
     git(["worktree", "prune"], cwd=project_root, check=False)
 
-    if wt_path.exists():
+    if wt_path.exists() or wt_path.is_symlink():
         die(f"worktree path already exists: {wt_path}. Run `worktree.py remove {sprint_num}` first.")
 
     # Create worktree on new branch off current HEAD (session branch).
@@ -94,18 +143,26 @@ def cmd_create(project_root: Path, args: list[str]) -> None:
         die(f"git worktree add failed: {result.stderr.strip() or result.stdout.strip()}")
 
     # Symlink .autonomous so coordination files stay in the main tree.
+    # Target is the literal project_root/.autonomous (NOT resolved) so
+    # redirection via a malicious .autonomous → /elsewhere is not silently
+    # propagated into every worktree.
     main_autonomous = project_root / ".autonomous"
-    main_autonomous.mkdir(exist_ok=True)
+    _assert_real_dir(main_autonomous, ".autonomous (re-check post-mkdir)")
+    try:
+        main_autonomous.mkdir(exist_ok=True)
+    except FileExistsError:
+        pass
+
     worktree_autonomous = wt_path / ".autonomous"
-    if worktree_autonomous.exists() or worktree_autonomous.is_symlink():
-        # Remove whatever's there — a fresh checkout shouldn't have .autonomous
-        # (it's gitignored) but belt-and-suspenders.
+    # A fresh worktree shouldn't have .autonomous (gitignored), but git may
+    # carry it through if a previous tree left a symlink. Remove defensively.
+    if worktree_autonomous.is_symlink() or worktree_autonomous.exists():
         if worktree_autonomous.is_symlink() or worktree_autonomous.is_file():
             worktree_autonomous.unlink()
         else:
             import shutil
             shutil.rmtree(worktree_autonomous)
-    worktree_autonomous.symlink_to(main_autonomous.resolve(), target_is_directory=True)
+    worktree_autonomous.symlink_to(main_autonomous, target_is_directory=True)
 
     print(str(wt_path.resolve()))
 
@@ -114,10 +171,10 @@ def cmd_remove(project_root: Path, args: list[str]) -> None:
     """remove <sprint-num>"""
     if not args:
         die("Usage: worktree.py remove <project-root> <sprint-num>")
-    try:
-        sprint_num = int(args[0])
-    except ValueError:
-        die(f"sprint-num must be integer, got: {args[0]}")
+    sprint_num = _validate_sprint_num(args[0])
+
+    if not is_git_repo(project_root):
+        die(f"not a git repo: {project_root}")
 
     wt_path = sprint_worktree_path(project_root, sprint_num)
 
@@ -127,11 +184,29 @@ def cmd_remove(project_root: Path, args: list[str]) -> None:
         print(f"worktree sprint-{sprint_num} not present (nothing to remove)")
         return
 
-    # Unlink the .autonomous symlink first so git worktree remove doesn't
-    # complain about unknown content or follow it into the main tree.
+    # Confirm this path is actually a git worktree known to the repo. Refuse
+    # to delete arbitrary directories even if they happen to live at
+    # .worktrees/sprint-N. This prevents the remove fallback from rmtree'ing
+    # user data that ended up at that path by accident.
+    list_result = git(["worktree", "list", "--porcelain"], cwd=project_root, check=False)
+    known_paths: set[str] = set()
+    for raw in list_result.stdout.splitlines():
+        if raw.startswith("worktree "):
+            known_paths.add(raw[len("worktree "):].strip())
+    if str(wt_path.resolve()) not in known_paths and str(wt_path) not in known_paths:
+        die(
+            f"refusing to remove: {wt_path} is not a registered git worktree. "
+            "If this is stale state, delete it manually."
+        )
+
+    # Unlink the .autonomous symlink so git worktree remove doesn't follow
+    # it into the main tree. Only unlink if it really is a symlink (never a
+    # real directory — that would mean state split already happened).
     wt_autonomous = wt_path / ".autonomous"
+    autonomous_unlinked = False
     if wt_autonomous.is_symlink():
         wt_autonomous.unlink()
+        autonomous_unlinked = True
 
     # --force removes even if the worktree has uncommitted changes. By the
     # time conductor calls remove(), evaluate-sprint has already read the
@@ -141,13 +216,37 @@ def cmd_remove(project_root: Path, args: list[str]) -> None:
         cwd=project_root,
         check=False,
     )
-    if result.returncode != 0:
-        # Fall back to prune + rmdir if git is confused about the worktree.
+    success = result.returncode == 0
+    if not success:
+        # Git refused to remove. Try pruning and cleaning up the directory,
+        # but ONLY if it's still under .worktrees/ (sanity re-check — the
+        # earlier registered-worktree check already validated this).
         git(["worktree", "prune"], cwd=project_root, check=False)
         if wt_path.exists():
+            resolved = wt_path.resolve()
+            expected_parent = worktree_root(project_root).resolve()
+            try:
+                resolved.relative_to(expected_parent)
+            except ValueError:
+                die(f"refusing to rmtree: {resolved} is not under {expected_parent}")
             import shutil
             shutil.rmtree(wt_path, ignore_errors=True)
-    print(f"worktree sprint-{sprint_num} removed")
+            success = not wt_path.exists()
+
+    # Restore the .autonomous symlink if we unlinked it but removal failed;
+    # otherwise the worktree is in a state-split condition (present without
+    # the symlink, so any .autonomous created locally is divergent data).
+    if not success and autonomous_unlinked and wt_path.exists():
+        try:
+            wt_autonomous.symlink_to(project_root / ".autonomous", target_is_directory=True)
+        except OSError:
+            pass
+        die(f"worktree remove failed: {result.stderr.strip() or result.stdout.strip()}")
+
+    if success:
+        print(f"worktree sprint-{sprint_num} removed")
+    else:
+        die(f"worktree remove failed: {result.stderr.strip() or result.stdout.strip()}")
 
 
 def cmd_list(project_root: Path, args: list[str]) -> None:

--- a/scripts/worktree.py
+++ b/scripts/worktree.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Per-sprint git worktree manager for autonomous-skill.
+
+Each sprint gets its own working directory at `<project>/.worktrees/sprint-N/`,
+bound to a dedicated branch. The main project tree stays on the session
+branch throughout — only worktrees switch between sprint branches. This
+isolates file changes between sprints and lets us avoid `git checkout -b`
+churn on the main tree.
+
+The worktree's `.autonomous/` is symlinked back to the main tree so coordination
+files (comms.json, conductor-state.json, sprint-N-summary.json, backlog.json)
+all go through a single source of truth. Workers and sprint masters read/write
+via `$(pwd)/.autonomous/` as before — the symlink is transparent.
+
+V1 scope: serial sprints, worktree per sprint, isolation only. Parallel
+dispatch + file-overlap guards are deferred to V2.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+
+def die(message: str) -> NoReturn:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def worktree_root(project_root: Path) -> Path:
+    return project_root / ".worktrees"
+
+
+def sprint_worktree_path(project_root: Path, sprint_num: int) -> Path:
+    return worktree_root(project_root) / f"sprint-{sprint_num}"
+
+
+def git(args: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def is_git_repo(path: Path) -> bool:
+    if not path.exists():
+        return False
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def cmd_create(project_root: Path, args: list[str]) -> None:
+    """create <sprint-num> <branch-name>"""
+    if len(args) < 2:
+        die("Usage: worktree.py create <project-root> <sprint-num> <branch-name>")
+    try:
+        sprint_num = int(args[0])
+    except ValueError:
+        die(f"sprint-num must be integer, got: {args[0]}")
+    branch_name = args[1]
+    if not branch_name.strip():
+        die("branch-name is required")
+
+    if not is_git_repo(project_root):
+        die(f"not a git repo: {project_root}")
+
+    wt_path = sprint_worktree_path(project_root, sprint_num)
+    worktree_root(project_root).mkdir(exist_ok=True)
+
+    # Prune stale entries before creating a new one. Harmless if nothing is stale.
+    git(["worktree", "prune"], cwd=project_root, check=False)
+
+    if wt_path.exists():
+        die(f"worktree path already exists: {wt_path}. Run `worktree.py remove {sprint_num}` first.")
+
+    # Create worktree on new branch off current HEAD (session branch).
+    result = git(
+        ["worktree", "add", str(wt_path), "-b", branch_name],
+        cwd=project_root,
+        check=False,
+    )
+    if result.returncode != 0:
+        die(f"git worktree add failed: {result.stderr.strip() or result.stdout.strip()}")
+
+    # Symlink .autonomous so coordination files stay in the main tree.
+    main_autonomous = project_root / ".autonomous"
+    main_autonomous.mkdir(exist_ok=True)
+    worktree_autonomous = wt_path / ".autonomous"
+    if worktree_autonomous.exists() or worktree_autonomous.is_symlink():
+        # Remove whatever's there — a fresh checkout shouldn't have .autonomous
+        # (it's gitignored) but belt-and-suspenders.
+        if worktree_autonomous.is_symlink() or worktree_autonomous.is_file():
+            worktree_autonomous.unlink()
+        else:
+            import shutil
+            shutil.rmtree(worktree_autonomous)
+    worktree_autonomous.symlink_to(main_autonomous.resolve(), target_is_directory=True)
+
+    print(str(wt_path.resolve()))
+
+
+def cmd_remove(project_root: Path, args: list[str]) -> None:
+    """remove <sprint-num>"""
+    if not args:
+        die("Usage: worktree.py remove <project-root> <sprint-num>")
+    try:
+        sprint_num = int(args[0])
+    except ValueError:
+        die(f"sprint-num must be integer, got: {args[0]}")
+
+    wt_path = sprint_worktree_path(project_root, sprint_num)
+
+    if not wt_path.exists():
+        # Idempotent: nothing to remove.
+        git(["worktree", "prune"], cwd=project_root, check=False)
+        print(f"worktree sprint-{sprint_num} not present (nothing to remove)")
+        return
+
+    # Unlink the .autonomous symlink first so git worktree remove doesn't
+    # complain about unknown content or follow it into the main tree.
+    wt_autonomous = wt_path / ".autonomous"
+    if wt_autonomous.is_symlink():
+        wt_autonomous.unlink()
+
+    # --force removes even if the worktree has uncommitted changes. By the
+    # time conductor calls remove(), evaluate-sprint has already read the
+    # summary, so any dirty state in the worktree is disposable.
+    result = git(
+        ["worktree", "remove", "--force", str(wt_path)],
+        cwd=project_root,
+        check=False,
+    )
+    if result.returncode != 0:
+        # Fall back to prune + rmdir if git is confused about the worktree.
+        git(["worktree", "prune"], cwd=project_root, check=False)
+        if wt_path.exists():
+            import shutil
+            shutil.rmtree(wt_path, ignore_errors=True)
+    print(f"worktree sprint-{sprint_num} removed")
+
+
+def cmd_list(project_root: Path, args: list[str]) -> None:
+    """list — list all git worktrees (including the main tree)"""
+    if not is_git_repo(project_root):
+        die(f"not a git repo: {project_root}")
+    result = git(["worktree", "list"], cwd=project_root, check=False)
+    sys.stdout.write(result.stdout)
+
+
+def cmd_ensure_gitignore(project_root: Path, args: list[str]) -> None:
+    """ensure-gitignore — append .worktrees/ to .gitignore if missing"""
+    gitignore = project_root / ".gitignore"
+    entry = ".worktrees/"
+
+    existing = ""
+    if gitignore.exists():
+        try:
+            existing = gitignore.read_text()
+        except OSError:
+            existing = ""
+
+    # Already present? Match exact line or .worktrees with/without trailing slash.
+    for line in existing.splitlines():
+        stripped = line.strip()
+        if stripped in {".worktrees", ".worktrees/", ".worktrees/*"}:
+            print("already present")
+            return
+
+    # Append with a leading newline if the file doesn't end with one.
+    to_write = existing
+    if to_write and not to_write.endswith("\n"):
+        to_write += "\n"
+    # Add a comment marker so future readers know why this is here.
+    to_write += "\n# autonomous-skill per-sprint worktrees\n"
+    to_write += entry + "\n"
+
+    try:
+        gitignore.write_text(to_write)
+    except OSError as exc:
+        die(f"failed to update .gitignore: {exc}")
+    print("added")
+
+
+def cmd_prune(project_root: Path, args: list[str]) -> None:
+    """prune — `git worktree prune` (remove stale admin entries)"""
+    if not is_git_repo(project_root):
+        die(f"not a git repo: {project_root}")
+    result = git(["worktree", "prune", "-v"], cwd=project_root, check=False)
+    sys.stdout.write(result.stdout)
+
+
+def cmd_path(project_root: Path, args: list[str]) -> None:
+    """path <sprint-num> — print the absolute path for a sprint's worktree"""
+    if not args:
+        die("Usage: worktree.py path <project-root> <sprint-num>")
+    try:
+        sprint_num = int(args[0])
+    except ValueError:
+        die(f"sprint-num must be integer, got: {args[0]}")
+    print(str(sprint_worktree_path(project_root, sprint_num).resolve()))
+
+
+def usage() -> None:
+    print(
+        """Usage: worktree.py <command> <project-root> [args...]
+
+Commands:
+  create <project> <sprint-num> <branch>   Create worktree at .worktrees/sprint-N
+                                           on a new branch, symlink .autonomous,
+                                           print absolute path
+  remove <project> <sprint-num>            Remove worktree (force); idempotent
+  list <project>                           `git worktree list`
+  ensure-gitignore <project>               Append .worktrees/ to .gitignore if missing
+  prune <project>                          `git worktree prune -v`
+  path <project> <sprint-num>              Print worktree absolute path (no side effects)
+
+Typical flow — conductor invokes these between Plan and Dispatch:
+  WT=$(python3 worktree.py create /path sprint-3 auto/session-X-sprint-3)
+  python3 dispatch.py "$WT" prompt.md sprint-3
+  # ... monitor + evaluate ...
+  python3 worktree.py remove /path 3
+""",
+        file=sys.stderr,
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) <= 1 or argv[1] in {"-h", "--help", "help"}:
+        usage()
+        return 0
+
+    cmd = argv[1]
+    project = Path(argv[2]).resolve() if len(argv) > 2 else Path.cwd()
+    args = argv[3:]
+
+    if cmd == "create":
+        cmd_create(project, args)
+    elif cmd == "remove":
+        cmd_remove(project, args)
+    elif cmd == "list":
+        cmd_list(project, args)
+    elif cmd == "ensure-gitignore":
+        cmd_ensure_gitignore(project, args)
+    elif cmd == "prune":
+        cmd_prune(project, args)
+    elif cmd == "path":
+        cmd_path(project, args)
+    else:
+        die(f"Unknown command: {cmd}. Use: create|remove|list|ensure-gitignore|prune|path")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/tests/test_worktree.sh
+++ b/tests/test_worktree.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WT="$SCRIPT_DIR/../scripts/worktree.py"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_worktree.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Helper: minimal git repo with one initial commit.
+make_repo() {
+  local p
+  p=$(new_tmp)
+  (cd "$p" && git init -q && git config user.email test@test && git config user.name test \
+    && git commit -q --allow-empty -m init) >/dev/null
+  echo "$p"
+}
+
+# ── 1. Help + unknown command ────────────────────────────────────────────
+
+echo ""
+echo "1. Help + unknown command"
+
+HELP=$(python3 "$WT" --help 2>&1)
+assert_contains "$HELP" "Usage: worktree.py" "--help shows usage"
+assert_contains "$HELP" "create" "--help documents create"
+assert_contains "$HELP" "remove" "--help documents remove"
+assert_contains "$HELP" "ensure-gitignore" "--help documents ensure-gitignore"
+assert_contains "$HELP" "prune" "--help documents prune"
+assert_contains "$HELP" "path" "--help documents path"
+
+if python3 "$WT" bogus "$(new_tmp)" 2>/dev/null; then
+  fail "unknown command should fail"
+else
+  ok "unknown command rejected"
+fi
+
+# ── 2. ensure-gitignore ──────────────────────────────────────────────────
+
+echo ""
+echo "2. ensure-gitignore"
+
+T=$(new_tmp)
+# Empty project, no .gitignore
+RESULT=$(python3 "$WT" ensure-gitignore "$T")
+assert_eq "$RESULT" "added" "adds to fresh .gitignore"
+assert_file_exists "$T/.gitignore" ".gitignore created"
+assert_file_contains "$T/.gitignore" ".worktrees/" ".worktrees/ entry present"
+
+# Idempotent
+RESULT2=$(python3 "$WT" ensure-gitignore "$T")
+assert_eq "$RESULT2" "already present" "second run is idempotent"
+LINE_COUNT=$(grep -c "^\.worktrees" "$T/.gitignore" || echo 0)
+assert_eq "$LINE_COUNT" "1" "no duplicate entry"
+
+# Also detects .worktrees without trailing slash
+T2=$(new_tmp)
+echo ".worktrees" > "$T2/.gitignore"
+RESULT3=$(python3 "$WT" ensure-gitignore "$T2")
+assert_eq "$RESULT3" "already present" "detects bare .worktrees"
+
+# Preserves existing content
+T3=$(new_tmp)
+echo "node_modules/" > "$T3/.gitignore"
+echo "*.log" >> "$T3/.gitignore"
+python3 "$WT" ensure-gitignore "$T3" > /dev/null
+assert_file_contains "$T3/.gitignore" "node_modules/" "preserves existing entries"
+assert_file_contains "$T3/.gitignore" "\*.log" "preserves all existing entries"
+assert_file_contains "$T3/.gitignore" ".worktrees/" "adds new entry"
+
+# ── 3. create: basic flow ────────────────────────────────────────────────
+
+echo ""
+echo "3. create basic flow"
+
+T=$(make_repo)
+WT_PATH=$(python3 "$WT" create "$T" 1 "auto/test-sprint-1")
+assert_contains "$WT_PATH" ".worktrees/sprint-1" "path follows convention"
+assert_file_exists "$WT_PATH/.git" "worktree has .git pointer"
+
+# Symlink to main .autonomous
+[ -L "$WT_PATH/.autonomous" ] && ok "worktree's .autonomous is a symlink" || fail ".autonomous not a symlink"
+
+# Symlink target is main tree's .autonomous
+mkdir -p "$T/.autonomous"
+echo "marker" > "$T/.autonomous/test.txt"
+CONTENT=$(cat "$WT_PATH/.autonomous/test.txt")
+assert_eq "$CONTENT" "marker" "symlink resolves to main tree's .autonomous"
+
+# git worktree list shows it
+LIST=$(python3 "$WT" list "$T")
+assert_contains "$LIST" "auto/test-sprint-1" "list shows the new sprint branch"
+
+# Branch was created
+BRANCH_IN_WT=$(cd "$WT_PATH" && git rev-parse --abbrev-ref HEAD)
+assert_eq "$BRANCH_IN_WT" "auto/test-sprint-1" "worktree checked out on new branch"
+
+# Main tree stayed on original branch
+MAIN_BRANCH=$(cd "$T" && git rev-parse --abbrev-ref HEAD)
+[ "$MAIN_BRANCH" != "auto/test-sprint-1" ] && ok "main tree NOT switched" || fail "main tree unexpectedly moved"
+
+# ── 4. create: validation ────────────────────────────────────────────────
+
+echo ""
+echo "4. create validation"
+
+T=$(make_repo)
+if python3 "$WT" create "$T" 2>/dev/null; then
+  fail "create without sprint-num should fail"
+else
+  ok "create without sprint-num rejected"
+fi
+
+if python3 "$WT" create "$T" notanumber "branch" 2>/dev/null; then
+  fail "non-integer sprint-num should fail"
+else
+  ok "non-integer sprint-num rejected"
+fi
+
+if python3 "$WT" create "$T" 1 "" 2>/dev/null; then
+  fail "empty branch-name should fail"
+else
+  ok "empty branch-name rejected"
+fi
+
+# Non-git directory
+TNG=$(new_tmp)
+if python3 "$WT" create "$TNG" 1 "auto/x" 2>/dev/null; then
+  fail "non-git dir should fail"
+else
+  ok "non-git dir rejected"
+fi
+
+# ── 5. create: collision detection ───────────────────────────────────────
+
+echo ""
+echo "5. create collision"
+
+T=$(make_repo)
+python3 "$WT" create "$T" 1 "auto/sprint-1" > /dev/null
+if python3 "$WT" create "$T" 1 "auto/sprint-1-dup" 2>/dev/null; then
+  fail "duplicate sprint-num should fail"
+else
+  ok "duplicate sprint-num rejected"
+fi
+
+# ── 6. remove: basic flow ────────────────────────────────────────────────
+
+echo ""
+echo "6. remove basic flow"
+
+T=$(make_repo)
+python3 "$WT" create "$T" 1 "auto/test-sprint-1" > /dev/null
+RESULT=$(python3 "$WT" remove "$T" 1)
+assert_contains "$RESULT" "removed" "remove reports success"
+[ ! -d "$T/.worktrees/sprint-1" ] && ok "worktree directory gone" || fail "worktree still present"
+
+# Idempotent
+RESULT2=$(python3 "$WT" remove "$T" 1)
+assert_contains "$RESULT2" "not present" "remove on non-existent is idempotent"
+
+# git no longer tracks it
+LIST=$(python3 "$WT" list "$T")
+assert_not_contains "$LIST" "sprint-1" "git worktree list no longer shows it"
+
+# ── 7. remove: with uncommitted changes ──────────────────────────────────
+
+echo ""
+echo "7. remove with dirty state"
+
+T=$(make_repo)
+WT_PATH=$(python3 "$WT" create "$T" 2 "auto/dirty")
+# Write an uncommitted file
+echo "dirty" > "$WT_PATH/wip.txt"
+# --force path: should still succeed
+RESULT=$(python3 "$WT" remove "$T" 2)
+assert_contains "$RESULT" "removed" "remove --force handles dirty worktree"
+[ ! -d "$T/.worktrees/sprint-2" ] && ok "dirty worktree removed" || fail "dirty worktree survived"
+
+# ── 8. remove: validation ────────────────────────────────────────────────
+
+echo ""
+echo "8. remove validation"
+
+T=$(make_repo)
+if python3 "$WT" remove "$T" 2>/dev/null; then
+  fail "remove without sprint-num should fail"
+else
+  ok "remove without sprint-num rejected"
+fi
+
+if python3 "$WT" remove "$T" notanumber 2>/dev/null; then
+  fail "non-integer sprint-num should fail"
+else
+  ok "remove non-integer sprint-num rejected"
+fi
+
+# ── 9. path command ──────────────────────────────────────────────────────
+
+echo ""
+echo "9. path command"
+
+T=$(make_repo)
+P=$(python3 "$WT" path "$T" 5)
+assert_contains "$P" ".worktrees/sprint-5" "path returns expected location"
+
+# path doesn't create anything
+[ ! -d "$T/.worktrees" ] && ok "path is a pure query (no side effects)" || fail "path created directory"
+
+# ── 10. list on non-git dir ──────────────────────────────────────────────
+
+echo ""
+echo "10. list error paths"
+
+TNG=$(new_tmp)
+if python3 "$WT" list "$TNG" 2>/dev/null; then
+  fail "list on non-git dir should fail"
+else
+  ok "list on non-git rejected"
+fi
+
+# ── 11. Multiple sprint worktrees coexist ────────────────────────────────
+
+echo ""
+echo "11. Multiple sprints coexist"
+
+T=$(make_repo)
+WT1=$(python3 "$WT" create "$T" 1 "auto/s-1")
+WT2=$(python3 "$WT" create "$T" 2 "auto/s-2")
+WT3=$(python3 "$WT" create "$T" 3 "auto/s-3")
+
+LIST=$(python3 "$WT" list "$T")
+COUNT=$(echo "$LIST" | grep -c "sprint-" || echo 0)
+assert_eq "$COUNT" "3" "three sprint worktrees listed"
+
+# Each worktree is on its own branch
+B1=$(cd "$WT1" && git rev-parse --abbrev-ref HEAD)
+B2=$(cd "$WT2" && git rev-parse --abbrev-ref HEAD)
+B3=$(cd "$WT3" && git rev-parse --abbrev-ref HEAD)
+assert_eq "$B1" "auto/s-1" "sprint-1 branch correct"
+assert_eq "$B2" "auto/s-2" "sprint-2 branch correct"
+assert_eq "$B3" "auto/s-3" "sprint-3 branch correct"
+
+# Remove one, others stay
+python3 "$WT" remove "$T" 2 > /dev/null
+LIST2=$(python3 "$WT" list "$T")
+assert_contains "$LIST2" "auto/s-1" "sprint-1 survives after sprint-2 removed"
+assert_contains "$LIST2" "auto/s-3" "sprint-3 survives after sprint-2 removed"
+assert_not_contains "$LIST2" "auto/s-2" "sprint-2 gone"
+
+# ── 12. Prune handles external worktree deletion ────────────────────────
+
+echo ""
+echo "12. Prune handles external deletion"
+
+T=$(make_repo)
+WT_PATH=$(python3 "$WT" create "$T" 1 "auto/vanish")
+# Simulate someone rm -rf'ing the worktree outside git's knowledge
+rm -rf "$WT_PATH"
+# git worktree list would show it as "prunable"
+python3 "$WT" prune "$T" > /dev/null
+LIST=$(python3 "$WT" list "$T")
+assert_not_contains "$LIST" "vanish" "prune removed the stale worktree entry"
+
+# ── 13. Integration: .autonomous symlink survives writes ─────────────────
+
+echo ""
+echo "13. .autonomous symlink write-through"
+
+T=$(make_repo)
+mkdir -p "$T/.autonomous"
+WT_PATH=$(python3 "$WT" create "$T" 1 "auto/wts")
+
+# Write from worktree side — should land in main tree
+echo '{"status":"idle"}' > "$WT_PATH/.autonomous/comms.json"
+assert_file_contains "$T/.autonomous/comms.json" "idle" "worktree write visible in main tree"
+
+# Write from main side — should be visible in worktree
+echo '{"sprint":3}' > "$T/.autonomous/conductor-state.json"
+READBACK=$(cat "$WT_PATH/.autonomous/conductor-state.json")
+assert_contains "$READBACK" "sprint" "main tree write visible in worktree"
+
+print_results

--- a/tests/test_worktree.sh
+++ b/tests/test_worktree.sh
@@ -284,4 +284,103 @@ echo '{"sprint":3}' > "$T/.autonomous/conductor-state.json"
 READBACK=$(cat "$WT_PATH/.autonomous/conductor-state.json")
 assert_contains "$READBACK" "sprint" "main tree write visible in worktree"
 
+# ── 14. Adversarial regression (Codex review findings) ──────────────────
+
+echo ""
+echo "14. Adversarial regression (Codex findings)"
+
+# P1: .worktrees/ pre-existing as a symlink must be refused
+T=$(make_repo)
+VICTIM=$(new_tmp)
+mkdir -p "$VICTIM/would-be-pwned"
+ln -s "$VICTIM" "$T/.worktrees"
+if python3 "$WT" create "$T" 1 "auto/symlink-escape" 2>/dev/null; then
+  fail "create must refuse when .worktrees/ is a pre-existing symlink"
+else
+  ok "create refuses symlinked .worktrees/"
+fi
+[ ! -d "$VICTIM/sprint-1" ] && ok "no escape: nothing written into symlink target" || fail "symlink escape occurred"
+
+# .autonomous/ pre-existing as a symlink must be refused
+T=$(make_repo)
+VICTIM=$(new_tmp)
+ln -s "$VICTIM" "$T/.autonomous"
+if python3 "$WT" create "$T" 1 "auto/autonomous-escape" 2>/dev/null; then
+  fail "create must refuse when .autonomous/ is a pre-existing symlink"
+else
+  ok "create refuses symlinked .autonomous/"
+fi
+
+# P1: remove requires a git repo
+TNG=$(new_tmp)
+mkdir -p "$TNG/.worktrees/sprint-1"
+echo "user data" > "$TNG/.worktrees/sprint-1/important.txt"
+if python3 "$WT" remove "$TNG" 1 2>/dev/null; then
+  fail "remove on non-git directory should fail"
+else
+  ok "remove rejects non-git directory"
+fi
+[ -f "$TNG/.worktrees/sprint-1/important.txt" ] && \
+  ok "user data untouched when remove refused" || \
+  fail "CATASTROPHIC: user data deleted"
+
+# P1: remove refuses to delete a directory that isn't a registered worktree
+T=$(make_repo)
+mkdir -p "$T/.worktrees/sprint-99"
+echo "not a real worktree" > "$T/.worktrees/sprint-99/data.txt"
+if python3 "$WT" remove "$T" 99 2>/dev/null; then
+  fail "remove must refuse unregistered directory"
+else
+  ok "remove refuses directory not tracked by git worktree"
+fi
+[ -f "$T/.worktrees/sprint-99/data.txt" ] && ok "unregistered dir preserved" || fail "unregistered dir deleted"
+
+# P2: branch name validation (delegates to git check-ref-format)
+T=$(make_repo)
+for BAD_NAME in "-bad" "bad..name" "bad~name" "HEAD"; do
+  if python3 "$WT" create "$T" 99 "$BAD_NAME" 2>/dev/null; then
+    fail "invalid branch name '$BAD_NAME' should be rejected"
+  else
+    ok "invalid branch name rejected: $BAD_NAME"
+  fi
+done
+
+# P2: sprint-num must be >= 1
+T=$(make_repo)
+if python3 "$WT" create "$T" 0 "auto/zero" 2>/dev/null; then
+  fail "sprint-num 0 should be rejected"
+else
+  ok "sprint-num 0 rejected"
+fi
+if python3 "$WT" create "$T" -5 "auto/neg" 2>/dev/null; then
+  fail "negative sprint-num should be rejected"
+else
+  ok "negative sprint-num rejected"
+fi
+
+# Regression: idempotent remove doesn't lie about which case it hit
+T=$(make_repo)
+python3 "$WT" create "$T" 1 "auto/lie-check" > /dev/null
+OUT=$(python3 "$WT" remove "$T" 1)
+assert_contains "$OUT" "removed" "success message on real removal"
+OUT2=$(python3 "$WT" remove "$T" 1)
+assert_contains "$OUT2" "not present" "idempotent remove says 'not present', not 'removed'"
+
+# P1 verification: merge-sprint.py --keep-branch flag exists + skips branch -D
+T=$(make_repo)
+(cd "$T" && git checkout -b auto/session-test) > /dev/null 2>&1
+python3 "$WT" create "$T" 1 "auto/keeptest-sprint-1" > /dev/null
+# Add a commit in the sprint worktree so merge has something to do
+(cd "$T/.worktrees/sprint-1" && echo "data" > f.txt && git add f.txt && \
+  git -c user.email=t@t -c user.name=t commit -q -m "sprint work") > /dev/null
+MERGE_OUT=$(python3 "$SCRIPT_DIR/../scripts/merge-sprint.py" --keep-branch \
+  "auto/session-test" "auto/keeptest-sprint-1" 1 complete "test merge" \
+  --project-dir "$T" 2>&1)
+# Branch should STILL exist because we used --keep-branch
+BRANCH_EXISTS=$(cd "$T" && git show-ref --verify --quiet refs/heads/auto/keeptest-sprint-1 && echo yes || echo no)
+assert_eq "$BRANCH_EXISTS" "yes" "--keep-branch preserves sprint branch after merge"
+# Clean up
+python3 "$WT" remove "$T" 1 > /dev/null
+(cd "$T" && git branch -D auto/keeptest-sprint-1) > /dev/null 2>&1
+
 print_results


### PR DESCRIPTION
## Summary

Opt-in per-sprint git worktrees. When `AUTONOMOUS_SPRINT_WORKTREES=1`, each sprint runs in its own `.worktrees/sprint-N/` directory on its own branch. The main tree stays on the session branch throughout — no `git checkout -b` churn — and sprints can't step on each other's dirty files.

**V1 is deliberately narrow: serial sprints, isolation only.** Parallel dispatch + file-overlap guards are deferred.

Inspired by `obra/superpowers` + `wan-huiyan/subagent-driven-development` (the parallel fork). gstack was investigated but uses worktrees only for test isolation.

## Why

Current behavior: `git checkout -b auto/session-X-sprint-N` in the main tree for each sprint. Problems:
- Sprint N leaves uncommitted junk, sprint N+1 inherits it
- Can't run anything on the main tree while a sprint is in progress
- Switching between sprint branches churns the filesystem

After V1: main tree stays put, every sprint is its own world.

## How

```bash
AUTONOMOUS_SPRINT_WORKTREES=1 /autonomous 5 build REST API
```

1. Conductor calls `worktree.py ensure-gitignore` (adds `.worktrees/` to `.gitignore` if missing)
2. For each sprint: `worktree.py create <project> <sprint-num> <branch>` → `git worktree add .worktrees/sprint-N -b <branch>`
3. Symlink `<worktree>/.autonomous` → `<main-tree>/.autonomous` so coordination files stay single-sourced
4. Dispatch `claude -p` into the worktree
5. After evaluate: `worktree.py remove` (with `--force`, pre-cleanup before `merge-sprint.py`)
6. `merge-sprint.py` merges the branch into session branch on main tree and deletes the branch

## Design choices

| Decision | Why |
|---|---|
| Opt-in env var, default off | Architecture change; ship behind a flag, flip default after field testing |
| `.autonomous/` symlinked, not duplicated | Single source of truth for comms/state/summary/backlog; workers don't need to change |
| Remove worktree BEFORE `merge-sprint.py` | `git branch -D` refuses to delete a branch checked out in a worktree |
| `--force` on remove | After evaluate, WIP is disposable by definition |
| `.worktrees/` in gitignore | Prevent accidentally committing nested checkouts |
| No dependency-symlink tricks (node_modules) | Would add complexity; each worktree pays its own install cost (V2 concern) |
| No parallel dispatch yet | Needs file-overlap heuristic before merging 2+ sprints safely; V2 |

## What's explicitly deferred to V2

- Parallel sprint dispatch with `MAX_PARALLEL_SPRINTS` cap
- File-overlap check before parallelizing (borrowed from Superpowers fork's Step 1)
- `node_modules`/dep-cache sharing via symlink
- Baseline-test gate (run project tests in fresh worktree before worker touches anything)
- Keeping failed worktrees for inspection (currently always removed)

## Test plan

- [x] `bash tests/test_worktree.sh` — 49/49 passing
- [x] `python3 -m compileall scripts` clean
- [x] All other suites unaffected (test_loop's 8 pre-existing failures still match main)
- [x] Manual: create → write file in worktree → file lands in worktree dir, NOT main tree
- [x] Manual: `.autonomous/` symlink write-through verified in both directions