### PR TITLE
feat: user-config + first-time AskUserQuestion setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to autonomous-skill are documented here.
 ## [Unreleased]
 
 ### Added
-- `scripts/worktree.py` — per-sprint git worktree manager. Creates `.worktrees/sprint-N/` on a dedicated sprint branch, symlinks `.autonomous/` back to the main tree so coordination files stay single-sourced. Commands: `create`, `remove`, `list`, `ensure-gitignore`, `prune`, `path`. Refuses symlinked `.worktrees/` or `.autonomous/` to prevent repo escape; validates branch names via `git check-ref-format`; requires `is_git_repo` before remove.
+- `scripts/user-config.py` — global + project config, replaces scattered env vars as the source of truth for mode toggles. Commands: `check`, `get`, `set`, `setup`, `show`, `paths`. Precedence: env > `<project>/.autonomous/config.json` > `~/.claude/autonomous/config.json` > defaults. Reads legacy `.autonomous/skill-config.json` for back-compat.
+- First-time setup in `autonomous/SKILL.md` — when no global config exists, asks once via `AskUserQuestion` for `worktrees`, `careful_hook`, and `scope` (global/project), persists, never asks again.
+- `tests/test_user_config.sh` — 38 tests covering precedence, env overrides, legacy migration, validation, malformed-config resilience.
+- `scripts/worktree.py` — per-sprint git worktree manager (opt-in via `mode.worktrees`). Creates `.worktrees/sprint-N/` on a dedicated sprint branch, symlinks `.autonomous/` back to the main tree so coordination files stay single-sourced. Commands: `create`, `remove`, `list`, `ensure-gitignore`, `prune`, `path`. Refuses symlinked `.worktrees/` or `.autonomous/` to prevent repo escape; validates branch names via `git check-ref-format`; requires `is_git_repo` before remove.
 - `tests/test_worktree.sh` — 65 tests covering CRUD, validation, symlink escape refusal, unregistered-directory remove guard, branch name validation, `.autonomous` symlink write-through, and multi-sprint coexistence.
 
 ### Changed
-- `autonomous/SKILL.md` Dispatch phase — when `AUTONOMOUS_SPRINT_WORKTREES=1` is set, each sprint runs in its own worktree instead of flipping the main tree onto the sprint branch. Default remains OFF (opt-in). Merge runs first (with `--keep-branch`), then worktree removal, then branch delete — if merge conflicts, worktree and branch are preserved for forensics.
+- `scripts/persona.py` — OWNER.md now lives at `~/.claude/autonomous/OWNER.md` (global) by default. Legacy `~/.claude/skills/autonomous-skill/OWNER.md` is migrated on first run. When `persona.scope=project` is set in config, OWNER.md goes to `<project>/.autonomous/OWNER.md` instead.
+- `scripts/dispatch.py` — careful-hook toggle now sourced from user-config (`mode.careful_hook`). `AUTONOMOUS_WORKER_CAREFUL` env var still overrides for debugging.
+- `scripts/build-sprint-prompt.py` — template resolution chain: project `config.json` → project `skill-config.json` (legacy) → global `config.json` → skill-root `skill-config.json` → default.
+- `autonomous/SKILL.md` Dispatch phase — when `mode.worktrees=true` (or `AUTONOMOUS_SPRINT_WORKTREES=1`), each sprint runs in its own worktree instead of flipping the main tree onto the sprint branch. Merge runs first (with `--keep-branch`), then worktree removal, then branch delete — if merge conflicts, worktree and branch are preserved for forensics.
 - `scripts/merge-sprint.py` — adds `--keep-branch` flag (skip final `git branch -D`, worktree mode deletes the branch separately after worktree removal). Merge failures now return 1 with the merge aborted cleanly instead of raising.
 
 ## [0.6.0] — 2026-04-09

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/timeline.py` — Append-only JSONL session event log at `.autonomous/timeline.jsonl` (session-start, sprint-start, sprint-end, phase-transition, session-end)
 - `scripts/explore-scan.py` — Project scanner: scores 8 exploration dimensions via heuristics
 - `scripts/backlog.py` — Cross-session persistent backlog (progressive disclosure, mkdir locking, max 50 items)
+- `scripts/user-config.py` — Global + project config (mode toggles, template, persona scope). Precedence: env > project > global > defaults. Drives first-time AskUserQuestion setup; persists to `~/.claude/autonomous/config.json` or `<project>/.autonomous/config.json`.
 - `scripts/checkpoint.py` — Human-readable markdown snapshots of session state at `.autonomous/checkpoints/<ts>-<slug>.md` (save/list/latest/show)
 - `scripts/persona.py` — OWNER.md auto-generation from git history + project docs
 - `scripts/loop.py` — Standalone launcher (outside CC's skill system)
@@ -156,7 +157,7 @@ then set `{"template":"<name>"}` in `skill-config.json` (or the project override
 
 ## Testing
 
-650 tests across 12 suites, all pure bash:
+688 tests across 13 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -171,6 +172,7 @@ bash tests/test_timeline.sh     # 63 tests: append-only JSONL log, filters, cond
 bash tests/test_careful_hook.sh # 97 tests: PreToolUse hook pattern matching, adversarial bypasses, dispatch integration, window_name validation
 bash tests/test_checkpoint.sh   # 70 tests: save/list/latest/show, path-traversal rejection, YAML injection resistance, type-unsafe JSON, non-UTF8
 bash tests/test_worktree.sh     # 65 tests: per-sprint worktree CRUD, symlink escape refusal, branch validation, registered-worktree guard, merge-sprint --keep-branch
+bash tests/test_user_config.sh  # 38 tests: config precedence (env > project > global > defaults), legacy migration, path validation, malformed config resilience
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,46 @@ When contributing to this project, follow these rules:
 - Run `python3 -m compileall scripts` before committing Python changes
 - Run affected test suites before pushing
 
+### Sandbox verification (end-to-end, per PR)
+After unit tests pass, every PR that touches user-facing behavior gets an
+end-to-end sandbox run that exercises the full flow (fresh HOME, fresh git
+project, real subprocess invocations — not just stubs).
+
+**Delegate to a subagent, don't run sandbox scripts in the main session.**
+Rationale:
+- Sandbox output (raw command dumps, file listings, multi-step logs) pollutes
+  the main context window fast. A subagent isolates that noise.
+- Subagents can run a scenario matrix in parallel and report pass/fail only.
+- If the sandbox flags something, the main session still sees the summary + failure
+  details without drowning in everything that passed.
+
+Prompt shape (brief the subagent like a colleague — include branch, feature
+summary, precise scenarios, and what "pass" means per scenario):
+
+```
+You are a sandbox test runner for autonomous-skill at <path>. Branch <name>.
+Feature under test: <one paragraph>.
+
+Ensure you're on the branch, then run these scenarios:
+1. ...
+2. ...
+10. ...
+
+For each: print [PASS] or [FAIL] on one line with scenario number + brief reason.
+If FAIL, include the command output so we can diagnose.
+
+Safety:
+- Sandbox HOME (mktemp -d), sandbox git project (mktemp -d + git init) per scenario
+- Never write to the real ~/.claude/<anything>
+- Kill any stray claude processes you spawned
+
+Final line: SUMMARY: N/M passed.
+```
+
+Scope rule: any PR touching `scripts/`, `autonomous/SKILL.md`, `quickdo/SKILL.md`,
+or worker dispatch should add a sandbox run to its test plan. Pure doc/test
+changes can skip this.
+
 ### Commit messages
 - Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `perf:`
 - Lowercase, imperative, concise

--- a/autonomous/SKILL.md
+++ b/autonomous/SKILL.md
@@ -17,6 +17,8 @@ if [ ! -d "$SCRIPT_DIR/scripts" ]; then
 fi
 _UPD=$(bash "$SCRIPT_DIR/scripts/update-check.sh" 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
+CONFIG_STATUS=$(python3 "$SCRIPT_DIR/scripts/user-config.py" check "$(pwd)" 2>/dev/null || echo "needs-setup")
+echo "CONFIG_STATUS=$CONFIG_STATUS"
 python3 "$SCRIPT_DIR/scripts/persona.py" "$(pwd)" >/dev/null 2>&1
 python3 "$SCRIPT_DIR/scripts/startup.py" "$(pwd)"
 ```
@@ -27,6 +29,37 @@ If the startup block outputs `UPDATE_AVAILABLE <old> <new>`, tell the user:
 > Update with: `cd ~/.claude/skills/autonomous-skill && git pull`
 
 Then continue normally — don't block on the update.
+
+**If `CONFIG_STATUS=needs-setup`, run the First-Time Setup (below) BEFORE Discovery.**
+If `CONFIG_STATUS=configured`, skip setup silently.
+
+## First-Time Setup — Only Runs Once Per User
+
+This fires when no global config exists at `~/.claude/autonomous/config.json`.
+Ask the user three things with a single `AskUserQuestion` call (multi-question):
+
+1. **Worktree mode**: "Run each sprint in its own git worktree (file-level isolation between sprints)? Recommended: yes."
+   - A) Yes — enable worktree mode
+   - B) No — legacy inline `git checkout -b` mode
+2. **Careful hook**: "Install a safety hook that blocks catastrophic Bash commands (`rm -rf /`, `mkfs`, force-push to main, etc.) in dispatched workers? Recommended: yes."
+   - A) Yes — enable careful hook
+   - B) No
+3. **Scope**: "Save these settings globally (apply to every project) or just this project?"
+   - A) Global (recommended — `~/.claude/autonomous/config.json`)
+   - B) Project (only this repo — `.autonomous/config.json`)
+
+Persist the answers. Map A/B → on/off; map scope → `--scope global` or `--scope project --project $(pwd)`:
+
+```bash
+python3 "$SCRIPT_DIR/scripts/user-config.py" setup \
+  --scope "$_SCOPE" ${_SCOPE_PROJECT:-} \
+  --worktrees "$_WORKTREES" \
+  --careful "$_CAREFUL"
+```
+
+After setup, tell the user in one line what was saved (path + toggles), then continue to
+Discovery. The env vars `AUTONOMOUS_SPRINT_WORKTREES` / `AUTONOMOUS_WORKER_CAREFUL` still
+override config at invocation time (debugging escape hatch).
 
 ## Pre-flight
 
@@ -41,9 +74,11 @@ ask unnecessary questions, do NOT explain what you're about to do. Act.
 
 1. Run the Startup bash block above
 2. Run the Pre-flight bash block (parse args)
-3. If direction was given in args → say one sentence confirming it, then jump to Session
-4. If no direction → ask the user ONE question: "What should we work on?"
-5. Once you have a direction → jump to Session and start dispatching
+3. If `CONFIG_STATUS=needs-setup` from Startup → run the First-Time Setup
+   section (one `AskUserQuestion` with 3 questions, persist via `user-config.py setup`). Otherwise skip.
+4. If direction was given in args → say one sentence confirming it, then jump to Session
+5. If no direction → ask the user ONE question: "What should we work on?"
+6. Once you have a direction → jump to Session and start dispatching
 
 **Common mistake**: Reading all the instructions below and getting paralyzed.
 Don't. The instructions are reference material. Your job right now is:
@@ -181,11 +216,10 @@ python3 "$SCRIPT_DIR/scripts/conductor-state.py" sprint-start "$(pwd)" "$SPRINT_
 SPRINT_NUM=$(python3 -c "import json; d=json.load(open('.autonomous/conductor-state.json')); print(len(d['sprints']))")
 SPRINT_BRANCH="${SESSION_BRANCH}-sprint-${SPRINT_NUM}"
 
-# Two modes — worktree-per-sprint (opt-in) or inline branch switching (default).
-# Worktree mode keeps the main tree on the session branch and runs each sprint
-# in its own .worktrees/sprint-N/ directory, giving file-level isolation
-# between consecutive sprints. Enable with AUTONOMOUS_SPRINT_WORKTREES=1.
-if [ "${AUTONOMOUS_SPRINT_WORKTREES:-0}" = "1" ]; then
+# Worktree-vs-inline mode sourced from user-config (env var still overrides).
+# Env: AUTONOMOUS_SPRINT_WORKTREES=1 forces on; AUTONOMOUS_SPRINT_WORKTREES=0 forces off.
+WORKTREE_MODE=$(python3 "$SCRIPT_DIR/scripts/user-config.py" get mode.worktrees "$(pwd)" 2>/dev/null || echo "false")
+if [ "$WORKTREE_MODE" = "true" ]; then
   python3 "$SCRIPT_DIR/scripts/worktree.py" ensure-gitignore "$(pwd)" >/dev/null || true
   SPRINT_DIR=$(python3 "$SCRIPT_DIR/scripts/worktree.py" create "$(pwd)" "$SPRINT_NUM" "$SPRINT_BRANCH")
 else
@@ -228,7 +262,7 @@ conflicts — the worktree stays for inspection instead of being wiped before
 we know whether the merge succeeded.
 
 ```bash
-if [ "${AUTONOMOUS_SPRINT_WORKTREES:-0}" = "1" ]; then
+if [ "$WORKTREE_MODE" = "true" ]; then
   if python3 "$SCRIPT_DIR/scripts/merge-sprint.py" --keep-branch \
        "$SESSION_BRANCH" "$SPRINT_BRANCH" "$SPRINT_NUM" "$STATUS" "$SUMMARY"; then
     python3 "$SCRIPT_DIR/scripts/worktree.py" remove "$(pwd)" "$SPRINT_NUM" || true

--- a/scripts/build-sprint-prompt.py
+++ b/scripts/build-sprint-prompt.py
@@ -11,19 +11,40 @@ from pathlib import Path
 
 
 def read_template_name(project_dir: Path, script_dir: Path) -> str:
-    def load(path: Path) -> str | None:
+    """Template resolution order (first match wins):
+    1. `<project>/.autonomous/config.json` (new, via user-config.py)
+    2. `<project>/.autonomous/skill-config.json` (legacy, pre-user-config)
+    3. `~/.claude/autonomous/config.json` (new global)
+    4. `<skill_dir>/skill-config.json` (shipped default)
+    5. "default"
+    Names containing `/` or starting with `.` are rejected (path traversal)."""
+    def load_json(path: Path) -> dict:
         if not path.exists():
-            return None
+            return {}
         try:
             data = json.loads(path.read_text())
-        except json.JSONDecodeError:
-            return None
-        value = data.get("template")
-        return value if isinstance(value, str) and value else None
+        except (json.JSONDecodeError, OSError):
+            return {}
+        return data if isinstance(data, dict) else {}
 
-    project_val = load(project_dir / ".autonomous" / "skill-config.json")
-    root_val = load(script_dir / "skill-config.json")
-    name = project_val or root_val or "default"
+    def extract(data: dict, key_path: list[str]) -> str | None:
+        cur = data
+        for k in key_path:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(k)
+        return cur if isinstance(cur, str) and cur else None
+
+    candidates = [
+        extract(load_json(project_dir / ".autonomous" / "config.json"), ["mode", "template"]),
+        extract(load_json(project_dir / ".autonomous" / "skill-config.json"), ["template"]),
+        extract(
+            load_json(Path.home() / ".claude" / "autonomous" / "config.json"),
+            ["mode", "template"],
+        ),
+        extract(load_json(script_dir / "skill-config.json"), ["template"]),
+    ]
+    name = next((c for c in candidates if c), "default")
     if "/" in name or name.startswith("."):
         return "default"
     return name

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -33,10 +33,32 @@ def tmux_available() -> bool:
     )
 
 
+def _careful_enabled(project_dir: Path) -> bool:
+    """Honor env var first (debug override), fall through to user-config."""
+    env_raw = os.environ.get("AUTONOMOUS_WORKER_CAREFUL", "")
+    if env_raw:
+        return env_raw.lower() in {"1", "true", "yes", "on"}
+    config_script = Path(__file__).resolve().parent / "user-config.py"
+    if not config_script.exists():
+        return False
+    try:
+        result = subprocess.run(
+            [sys.executable, str(config_script), "get",
+             "mode.careful_hook", str(project_dir)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return result.stdout.strip() == "true"
+
+
 def careful_settings_path(project_dir: Path, window: str) -> Path | None:
     """Generate a per-session settings JSON registering the careful hook.
-    Returns the path when enabled (env var + hook script present), None otherwise."""
-    if os.environ.get("AUTONOMOUS_WORKER_CAREFUL", "").lower() not in {"1", "true", "yes"}:
+    Returns the path when enabled (via user-config or env var), None otherwise."""
+    if not _careful_enabled(project_dir):
         return None
     hook_script = Path(__file__).resolve().parent / "hooks" / "careful.sh"
     if not hook_script.exists():

--- a/scripts/persona.py
+++ b/scripts/persona.py
@@ -109,12 +109,42 @@ def main(argv: list[str]) -> int:
 
     project = Path(args.project_dir).resolve()
     script_dir = Path(__file__).resolve().parent
-    owner_file = script_dir.parent / "OWNER.md"
     template_file = script_dir.parent / "OWNER.md.template"
+
+    # Resolve OWNER.md location via user-config:
+    #   - persona.scope=project → <project>/.autonomous/OWNER.md
+    #   - persona.scope=global (default) → ~/.claude/autonomous/OWNER.md
+    # Fall through to legacy skill-root OWNER.md for back-compat so users who
+    # already have one don't lose it on upgrade.
+    sys.path.insert(0, str(script_dir))
+    try:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "user_config", script_dir / "user-config.py"
+        )
+        uc_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(uc_module)  # type: ignore[union-attr]
+        cfg = uc_module.load_effective(project)
+        scope = cfg.get("persona", {}).get("scope", "global")
+        if scope == "project":
+            owner_file = project / ".autonomous" / "OWNER.md"
+        else:
+            owner_file = uc_module.global_owner_path()
+        legacy_owner = script_dir.parent / "OWNER.md"
+    except Exception:  # pragma: no cover — user-config must never break persona
+        owner_file = script_dir.parent / "OWNER.md"
+        legacy_owner = owner_file
+
+    # Migrate: if the new location is empty but the legacy one has content,
+    # copy it rather than regenerate from scratch.
+    if not owner_file.exists() and legacy_owner != owner_file and legacy_owner.exists():
+        owner_file.parent.mkdir(parents=True, exist_ok=True)
+        owner_file.write_text(legacy_owner.read_text(encoding="utf-8"), encoding="utf-8")
 
     if owner_file.exists():
         print(owner_file)
         return 0
+    owner_file.parent.mkdir(parents=True, exist_ok=True)
 
     git_log, claude_md, readme = gather_context(project)
     if not any([git_log, claude_md, readme]):

--- a/scripts/user-config.py
+++ b/scripts/user-config.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""User config + mode selection for autonomous-skill.
+
+Two scopes, precedence high → low:
+1. Environment variables (temporary override — debugging)
+2. Project config at `<project>/.autonomous/config.json`
+3. Global config at `~/.claude/autonomous/config.json`
+4. Built-in defaults
+
+Why two scopes:
+- Global = "my normal preferences across every repo" (most users)
+- Project = "this one repo needs different settings" (escape hatch)
+
+Why a separate `~/.claude/autonomous/` dir (not inside the skill dir):
+- The skill is git-managed (`~/.claude/skills/autonomous-skill/`), so putting
+  user data inside it creates conflicts on `git pull` updates.
+
+Commands:
+  check <project>           — print one of: configured | needs-setup
+                              SKILL.md reads this at startup to decide whether
+                              to run the first-time AskUserQuestion flow.
+  get <key> [project]       — print the effective value (with env overrides).
+                              Example keys: mode.worktrees, mode.careful_hook,
+                              mode.template, persona.scope
+  set <key> <value> [--scope global|project] [--project <dir>]
+                            — persist a value at the chosen scope.
+  setup [--scope global|project] [--project <dir>]
+        [--worktrees on|off] [--careful on|off] [--template <name>]
+                            — write a full initial config in one shot.
+                              Used by SKILL.md after the AskUserQuestion flow.
+  show [--scope global|project|effective] [--project <dir>]
+                            — dump the config as JSON.
+  paths [--project <dir>]   — print resolved global/project paths (for debugging).
+
+Values:
+  mode.worktrees, mode.careful_hook  → bool (true|false)
+  mode.template                      → string (gstack|default|<custom>)
+  persona.scope                      → string (global|project)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, NoReturn
+
+VERSION = 1
+
+# Keys that are user-toggleable. Env-var names where applicable.
+ENV_OVERRIDES: dict[str, str] = {
+    "mode.worktrees": "AUTONOMOUS_SPRINT_WORKTREES",
+    "mode.careful_hook": "AUTONOMOUS_WORKER_CAREFUL",
+}
+
+BOOL_KEYS = {"mode.worktrees", "mode.careful_hook"}
+STRING_KEYS = {"mode.template", "persona.scope"}
+VALID_TEMPLATES = {"gstack", "default"}
+VALID_PERSONA_SCOPES = {"global", "project"}
+
+DEFAULTS: dict[str, Any] = {
+    "mode": {
+        "worktrees": False,
+        "careful_hook": False,
+        "template": "gstack",
+    },
+    "persona": {
+        "scope": "global",
+        "last_generated": None,
+    },
+}
+
+
+def die(message: str) -> NoReturn:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def global_dir() -> Path:
+    return Path.home() / ".claude" / "autonomous"
+
+
+def global_config_path() -> Path:
+    return global_dir() / "config.json"
+
+
+def global_owner_path() -> Path:
+    return global_dir() / "OWNER.md"
+
+
+def project_config_path(project: Path) -> Path:
+    return project / ".autonomous" / "config.json"
+
+
+def project_owner_path(project: Path) -> Path:
+    return project / ".autonomous" / "OWNER.md"
+
+
+def legacy_skill_config_path(project: Path) -> Path:
+    """Old per-project template selector (pre-user-config)."""
+    return project / ".autonomous" / "skill-config.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    """Return a dict or {} — never raises, never returns non-dict."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Overlay wins on leaf conflicts; nested dicts merge recursively."""
+    result = dict(base)
+    for key, value in overlay.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(value, dict)
+        ):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _parse_bool_env(raw: str) -> bool | None:
+    if raw.lower() in {"1", "true", "yes", "on"}:
+        return True
+    if raw.lower() in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def _get_nested(data: dict[str, Any], dotted: str) -> Any:
+    cur: Any = data
+    for part in dotted.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def _set_nested(data: dict[str, Any], dotted: str, value: Any) -> None:
+    parts = dotted.split(".")
+    cur: Any = data
+    for part in parts[:-1]:
+        if part not in cur or not isinstance(cur[part], dict):
+            cur[part] = {}
+        cur = cur[part]
+    cur[parts[-1]] = value
+
+
+def load_effective(project: Path | None) -> dict[str, Any]:
+    """Merged view: defaults ← global ← project. No env overrides applied here."""
+    merged = json.loads(json.dumps(DEFAULTS))  # deep copy
+    merged = _deep_merge(merged, _load_json(global_config_path()))
+    if project is not None:
+        # Backward compat: pull template out of legacy skill-config.json if the
+        # new config.json doesn't exist in the project.
+        project_cfg_path = project_config_path(project)
+        if not project_cfg_path.exists():
+            legacy = _load_json(legacy_skill_config_path(project))
+            if legacy.get("template"):
+                merged["mode"]["template"] = legacy["template"]
+        else:
+            merged = _deep_merge(merged, _load_json(project_cfg_path))
+    return merged
+
+
+def is_configured() -> bool:
+    """Global config exists? That's our 'has the user ever set this up' test."""
+    return global_config_path().exists()
+
+
+def cmd_check(args: argparse.Namespace) -> None:
+    """Print 'configured' or 'needs-setup'. Called from SKILL.md startup."""
+    print("configured" if is_configured() else "needs-setup")
+
+
+def _coerce_value(key: str, raw: str) -> Any:
+    if key in BOOL_KEYS:
+        parsed = _parse_bool_env(raw)
+        if parsed is None:
+            die(f"invalid bool for {key}: {raw} (use true|false|on|off)")
+        return parsed
+    if key == "mode.template":
+        cleaned = raw.strip()
+        if not cleaned:
+            die("template name is required")
+        # Safety: reject path traversal / dot-prefix like build-sprint-prompt.py
+        if cleaned.startswith(".") or "/" in cleaned or "\\" in cleaned:
+            die(f"invalid template name: {cleaned}")
+        return cleaned
+    if key == "persona.scope":
+        if raw not in VALID_PERSONA_SCOPES:
+            die(f"invalid scope: {raw} (use global|project)")
+        return raw
+    if key in STRING_KEYS:
+        return raw
+    die(f"unknown key: {key}")
+
+
+def cmd_get(args: argparse.Namespace) -> None:
+    project = Path(args.project).resolve() if args.project else None
+    cfg = load_effective(project)
+
+    # Env override wins
+    env_name = ENV_OVERRIDES.get(args.key)
+    if env_name and env_name in os.environ and os.environ[env_name]:
+        parsed = _parse_bool_env(os.environ[env_name])
+        if parsed is not None:
+            print("true" if parsed else "false")
+            return
+
+    value = _get_nested(cfg, args.key)
+    if isinstance(value, bool):
+        print("true" if value else "false")
+    elif value is None:
+        print("")
+    else:
+        print(value)
+
+
+def _write_at_scope(
+    scope: str,
+    project: Path | None,
+    mutation: "callable",
+) -> Path:
+    if scope == "global":
+        path = global_config_path()
+    elif scope == "project":
+        if project is None:
+            die("--project is required when --scope=project")
+        path = project_config_path(project)
+    else:
+        die(f"invalid scope: {scope} (use global|project)")
+    existing = _load_json(path)
+    if not existing:
+        # Minimal skeleton only. Do NOT seed defaults here: that would cause
+        # a project-scope write to shadow keys the user set globally (e.g.,
+        # setting mode.worktrees=false at project would also write
+        # mode.careful_hook=false and erase the inherited global value).
+        existing = {"version": VERSION, "created_at": now_iso()}
+    mutation(existing)
+    existing["updated_at"] = now_iso()
+    existing.setdefault("version", VERSION)
+    _atomic_write_json(path, existing)
+    return path
+
+
+def cmd_set(args: argparse.Namespace) -> None:
+    key, value = args.key, args.value
+    coerced = _coerce_value(key, value)
+    project = Path(args.project).resolve() if args.project else None
+
+    def mutate(cfg: dict[str, Any]) -> None:
+        _set_nested(cfg, key, coerced)
+
+    path = _write_at_scope(args.scope, project, mutate)
+    print(f"{key}={coerced} saved to {path}")
+
+
+def cmd_setup(args: argparse.Namespace) -> None:
+    """Write a complete fresh config — the target of the first-time flow."""
+    project = Path(args.project).resolve() if args.project else None
+    worktrees = _parse_bool_env(args.worktrees) if args.worktrees else None
+    careful = _parse_bool_env(args.careful) if args.careful else None
+    if args.worktrees and worktrees is None:
+        die(f"invalid --worktrees: {args.worktrees}")
+    if args.careful and careful is None:
+        die(f"invalid --careful: {args.careful}")
+    if args.template and args.template not in VALID_TEMPLATES and (
+        args.template.startswith(".") or "/" in args.template
+    ):
+        die(f"invalid --template: {args.template}")
+
+    def mutate(cfg: dict[str, Any]) -> None:
+        if worktrees is not None:
+            _set_nested(cfg, "mode.worktrees", worktrees)
+        if careful is not None:
+            _set_nested(cfg, "mode.careful_hook", careful)
+        if args.template:
+            _set_nested(cfg, "mode.template", args.template)
+        if args.persona_scope:
+            if args.persona_scope not in VALID_PERSONA_SCOPES:
+                die(f"invalid --persona-scope: {args.persona_scope}")
+            _set_nested(cfg, "persona.scope", args.persona_scope)
+
+    path = _write_at_scope(args.scope, project, mutate)
+    print(f"config saved to {path}")
+
+
+def cmd_show(args: argparse.Namespace) -> None:
+    project = Path(args.project).resolve() if args.project else None
+    scope = args.scope
+    if scope == "global":
+        data = _load_json(global_config_path())
+    elif scope == "project":
+        if project is None:
+            die("--project is required when --scope=project")
+        data = _load_json(project_config_path(project))
+    else:  # effective (default)
+        data = load_effective(project)
+    print(json.dumps(data, indent=2))
+
+
+def cmd_paths(args: argparse.Namespace) -> None:
+    project = Path(args.project).resolve() if args.project else None
+    print(f"global_dir:      {global_dir()}")
+    print(f"global_config:   {global_config_path()}")
+    print(f"global_owner:    {global_owner_path()}")
+    if project:
+        print(f"project_dir:     {project}")
+        print(f"project_config:  {project_config_path(project)}")
+        print(f"project_owner:   {project_owner_path(project)}")
+        print(f"legacy_config:   {legacy_skill_config_path(project)}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="user-config.py",
+        description=__doc__.splitlines()[0] if __doc__ else "",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_check = sub.add_parser("check", help="print 'configured' or 'needs-setup'")
+    p_check.add_argument("project", nargs="?", default=None)
+    p_check.set_defaults(func=cmd_check)
+
+    p_get = sub.add_parser("get", help="get a config value (env overrides apply)")
+    p_get.add_argument("key")
+    p_get.add_argument("project", nargs="?", default=None)
+    p_get.set_defaults(func=cmd_get)
+
+    p_set = sub.add_parser("set", help="persist a config value")
+    p_set.add_argument("key")
+    p_set.add_argument("value")
+    p_set.add_argument("--scope", choices=["global", "project"], default="global")
+    p_set.add_argument("--project", default=None)
+    p_set.set_defaults(func=cmd_set)
+
+    p_setup = sub.add_parser(
+        "setup",
+        help="write a full fresh config (used by SKILL.md after first-time AskUserQuestion)",
+    )
+    p_setup.add_argument("--scope", choices=["global", "project"], default="global")
+    p_setup.add_argument("--project", default=None)
+    p_setup.add_argument("--worktrees", default=None, help="on|off")
+    p_setup.add_argument("--careful", default=None, help="on|off")
+    p_setup.add_argument("--template", default=None)
+    p_setup.add_argument(
+        "--persona-scope",
+        default=None,
+        choices=list(VALID_PERSONA_SCOPES),
+        help="where OWNER.md lives (default global)",
+    )
+    p_setup.set_defaults(func=cmd_setup)
+
+    p_show = sub.add_parser("show", help="print config JSON")
+    p_show.add_argument(
+        "--scope",
+        choices=["global", "project", "effective"],
+        default="effective",
+    )
+    p_show.add_argument("--project", default=None)
+    p_show.set_defaults(func=cmd_show)
+
+    p_paths = sub.add_parser("paths", help="print resolved paths (debug)")
+    p_paths.add_argument("--project", default=None)
+    p_paths.set_defaults(func=cmd_paths)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv[1:])
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/tests/test_persona.sh
+++ b/tests/test_persona.sh
@@ -2,8 +2,8 @@
 # Tests for scripts/persona.py
 # Uses tests/claude mock binary — no real API calls.
 #
-# OWNER.md is now GLOBAL (lives in skill root dir, not per-project).
-# Tests back up and restore the real OWNER.md to avoid side effects.
+# OWNER.md is now GLOBAL at ~/.claude/autonomous/OWNER.md (via user-config).
+# Tests sandbox HOME to a tmpdir so the real user config isn't touched.
 
 set -euo pipefail
 
@@ -11,24 +11,30 @@ source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PERSONA_SH="$REPO_ROOT/scripts/persona.py"
-GLOBAL_OWNER="$REPO_ROOT/OWNER.md"
+
+# Sandbox HOME so ~/.claude/autonomous/OWNER.md goes to a tmpdir.
+TEST_HOME=$(mktemp -d)
+export HOME="$TEST_HOME"
+GLOBAL_OWNER="$TEST_HOME/.claude/autonomous/OWNER.md"
 
 # Intercept 'claude' with mock before real binary
 export PATH="$REPO_ROOT/tests:$PATH"
 
-# Back up existing global OWNER.md (restore at end)
-OWNER_BACKUP=""
-if [ -f "$GLOBAL_OWNER" ]; then
-  OWNER_BACKUP=$(mktemp)
-  cp "$GLOBAL_OWNER" "$OWNER_BACKUP"
+# Temporarily hide the skill-root legacy OWNER.md so persona.py's back-compat
+# migration doesn't copy it into our sandbox (which would mask generation).
+LEGACY_OWNER="$REPO_ROOT/OWNER.md"
+LEGACY_BACKUP=""
+if [ -f "$LEGACY_OWNER" ]; then
+  LEGACY_BACKUP=$(mktemp)
+  mv "$LEGACY_OWNER" "$LEGACY_BACKUP"
 fi
 
-# Extend existing cleanup trap from test_helpers.sh
+# Clean up tmp HOME + restore legacy OWNER.md on exit
 _orig_cleanup=$(trap -p EXIT | sed "s/trap -- '//;s/' EXIT//")
 restore_and_cleanup() {
-  if [ -n "$OWNER_BACKUP" ] && [ -f "$OWNER_BACKUP" ]; then
-    cp "$OWNER_BACKUP" "$GLOBAL_OWNER"
-    rm -f "$OWNER_BACKUP"
+  rm -rf "$TEST_HOME"
+  if [ -n "$LEGACY_BACKUP" ] && [ -f "$LEGACY_BACKUP" ]; then
+    mv "$LEGACY_BACKUP" "$LEGACY_OWNER"
   fi
   eval "$_orig_cleanup"
 }
@@ -38,6 +44,11 @@ trap restore_and_cleanup EXIT
 remove_global_owner() {
   rm -f "$GLOBAL_OWNER"
 }
+
+# The global OWNER.md now lives under HOME, not the repo. Make sure the parent
+# dir exists before tests that write directly to $GLOBAL_OWNER (persona.py
+# creates it itself via mkdir(parents=True, exist_ok=True)).
+mkdir -p "$(dirname "$GLOBAL_OWNER")"
 
 # ── Tests ───────────────────────────────────────────────────────────────────
 echo ""

--- a/tests/test_user_config.sh
+++ b/tests/test_user_config.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UC="$SCRIPT_DIR/../scripts/user-config.py"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_user_config.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Every test uses a sandboxed HOME so the real user config isn't touched.
+sandbox_home() {
+  local h
+  h=$(new_tmp)
+  echo "$h"
+}
+
+make_project() {
+  local p
+  p=$(new_tmp)
+  (cd "$p" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init) >/dev/null
+  echo "$p"
+}
+
+# ── 1. Help + unknown command ────────────────────────────────────────────
+
+echo ""
+echo "1. Help + CLI surface"
+
+HELP=$(python3 "$UC" --help 2>&1)
+assert_contains "$HELP" "check" "--help documents check"
+assert_contains "$HELP" "get" "--help documents get"
+assert_contains "$HELP" "set" "--help documents set"
+assert_contains "$HELP" "setup" "--help documents setup"
+assert_contains "$HELP" "show" "--help documents show"
+
+if python3 "$UC" bogus 2>/dev/null; then
+  fail "unknown subcommand should fail"
+else
+  ok "unknown subcommand rejected"
+fi
+
+# ── 2. check: needs-setup vs configured ──────────────────────────────────
+
+echo ""
+echo "2. check subcommand"
+
+H=$(sandbox_home)
+T=$(make_project)
+OUT=$(HOME="$H" python3 "$UC" check "$T")
+assert_eq "$OUT" "needs-setup" "fresh HOME → needs-setup"
+
+HOME="$H" python3 "$UC" setup --scope global --worktrees on --careful off > /dev/null
+OUT=$(HOME="$H" python3 "$UC" check "$T")
+assert_eq "$OUT" "configured" "after setup → configured"
+
+# ── 3. setup writes complete config ──────────────────────────────────────
+
+echo ""
+echo "3. setup writes full config"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --worktrees on --careful on --template gstack --persona-scope global > /dev/null
+CONFIG="$H/.claude/autonomous/config.json"
+assert_file_exists "$CONFIG" "global config written"
+assert_file_contains "$CONFIG" '"worktrees": true' "worktrees on persisted"
+assert_file_contains "$CONFIG" '"careful_hook": true' "careful on persisted"
+assert_file_contains "$CONFIG" '"template": "gstack"' "template persisted"
+assert_file_contains "$CONFIG" '"scope": "global"' "persona scope persisted"
+assert_file_contains "$CONFIG" '"version": 1' "version field present"
+assert_file_contains "$CONFIG" '"created_at"' "created_at present"
+
+# ── 4. get: reads value from global ──────────────────────────────────────
+
+echo ""
+echo "4. get from global"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" setup --scope global --worktrees on > /dev/null
+WT=$(HOME="$H" python3 "$UC" get mode.worktrees "$T")
+assert_eq "$WT" "true" "global worktrees=on read as true"
+CH=$(HOME="$H" python3 "$UC" get mode.careful_hook "$T")
+assert_eq "$CH" "false" "global careful unset → default false"
+TMPL=$(HOME="$H" python3 "$UC" get mode.template "$T")
+assert_eq "$TMPL" "gstack" "template default=gstack"
+
+# ── 5. project overrides global ─────────────────────────────────────────
+
+echo ""
+echo "5. project overrides global"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" setup --scope global --worktrees on --careful on > /dev/null
+HOME="$H" python3 "$UC" set mode.worktrees false --scope project --project "$T" > /dev/null
+WT=$(HOME="$H" python3 "$UC" get mode.worktrees "$T")
+assert_eq "$WT" "false" "project worktrees=false beats global=true"
+# careful is unset at project → inherits global
+CH=$(HOME="$H" python3 "$UC" get mode.careful_hook "$T")
+assert_eq "$CH" "true" "careful inherits from global (not set at project)"
+
+# ── 6. env var beats everything ──────────────────────────────────────────
+
+echo ""
+echo "6. env var overrides project+global"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" setup --scope global --worktrees on > /dev/null
+WT=$(HOME="$H" AUTONOMOUS_SPRINT_WORKTREES=0 python3 "$UC" get mode.worktrees "$T")
+assert_eq "$WT" "false" "env=0 overrides global=true"
+WT=$(HOME="$H" AUTONOMOUS_SPRINT_WORKTREES=yes python3 "$UC" get mode.worktrees "$T")
+assert_eq "$WT" "true" "env=yes overrides"
+CH=$(HOME="$H" AUTONOMOUS_WORKER_CAREFUL=true python3 "$UC" get mode.careful_hook "$T")
+assert_eq "$CH" "true" "careful env override works"
+
+# ── 7. legacy skill-config.json migration path ──────────────────────────
+
+echo ""
+echo "7. legacy skill-config.json → template"
+
+H=$(sandbox_home)
+T=$(make_project)
+mkdir -p "$T/.autonomous"
+# Pre-existing legacy file (old users have this)
+echo '{"template":"default"}' > "$T/.autonomous/skill-config.json"
+TMPL=$(HOME="$H" python3 "$UC" get mode.template "$T")
+assert_eq "$TMPL" "default" "legacy skill-config.json read as template"
+
+# New config.json should win over legacy
+HOME="$H" python3 "$UC" set mode.template custom-tpl --scope project --project "$T" > /dev/null
+TMPL=$(HOME="$H" python3 "$UC" get mode.template "$T")
+assert_eq "$TMPL" "custom-tpl" "new config.json beats legacy skill-config.json"
+
+# ── 8. set: validation ──────────────────────────────────────────────────
+
+echo ""
+echo "8. set validation"
+
+H=$(sandbox_home)
+if HOME="$H" python3 "$UC" set mode.worktrees notabool --scope global 2>/dev/null; then
+  fail "invalid bool should be rejected"
+else
+  ok "invalid bool rejected"
+fi
+if HOME="$H" python3 "$UC" set mode.template "../path" --scope global 2>/dev/null; then
+  fail "path-traversal template should be rejected"
+else
+  ok "path-traversal template rejected"
+fi
+if HOME="$H" python3 "$UC" set mode.template ".hidden" --scope global 2>/dev/null; then
+  fail "dot-prefix template should be rejected"
+else
+  ok "dot-prefix template rejected"
+fi
+if HOME="$H" python3 "$UC" set persona.scope elsewhere --scope global 2>/dev/null; then
+  fail "invalid persona scope should be rejected"
+else
+  ok "invalid persona scope rejected"
+fi
+if HOME="$H" python3 "$UC" set mode.worktrees true --scope project 2>/dev/null; then
+  fail "project scope without --project should fail"
+else
+  ok "project scope requires --project"
+fi
+
+# ── 9. show: effective vs scoped ────────────────────────────────────────
+
+echo ""
+echo "9. show subcommand"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" setup --scope global --worktrees on --template gstack > /dev/null
+HOME="$H" python3 "$UC" set mode.worktrees false --scope project --project "$T" > /dev/null
+
+EFFECTIVE=$(HOME="$H" python3 "$UC" show --project "$T")
+assert_contains "$EFFECTIVE" '"worktrees": false' "effective shows project override"
+assert_contains "$EFFECTIVE" '"template": "gstack"' "effective includes global template"
+
+GLOBAL_ONLY=$(HOME="$H" python3 "$UC" show --scope global)
+assert_contains "$GLOBAL_ONLY" '"worktrees": true' "global scope shows true"
+
+PROJECT_ONLY=$(HOME="$H" python3 "$UC" show --scope project --project "$T")
+assert_contains "$PROJECT_ONLY" '"worktrees": false' "project scope shows false"
+
+# ── 10. paths ────────────────────────────────────────────────────────────
+
+echo ""
+echo "10. paths subcommand"
+
+H=$(sandbox_home)
+T=$(make_project)
+OUT=$(HOME="$H" python3 "$UC" paths --project "$T")
+assert_contains "$OUT" "$H/.claude/autonomous/config.json" "global config path shown"
+assert_contains "$OUT" "$T/.autonomous/config.json" "project config path shown"
+assert_contains "$OUT" "OWNER.md" "owner path shown"
+
+# ── 11. malformed config resilience ─────────────────────────────────────
+
+echo ""
+echo "11. malformed config doesn't crash"
+
+H=$(sandbox_home)
+T=$(make_project)
+mkdir -p "$H/.claude/autonomous" "$T/.autonomous"
+echo "not valid json" > "$H/.claude/autonomous/config.json"
+echo '["list","not","dict"]' > "$T/.autonomous/config.json"
+OUT=$(HOME="$H" python3 "$UC" get mode.worktrees "$T" 2>&1)
+assert_eq "$OUT" "false" "malformed configs fall through to default"
+
+print_results


### PR DESCRIPTION
## Summary

Replaces scattered env vars (`AUTONOMOUS_SPRINT_WORKTREES`, `AUTONOMOUS_WORKER_CAREFUL`, `skill-config.json`) with a unified `user-config.py` that persists global + project preferences. On first run, the skill asks the user three questions once via `AskUserQuestion`, writes the config, and never asks again.

## Why

Every mode toggle was a hidden env var. Users who didn't know about them never got the benefits (worktree isolation, safety hook). This PR makes those choices a **first-class first-run decision** — you pick once, it persists, you can override per-project or via env var for debugging.

## User experience

**First run** (no `~/.claude/autonomous/config.json`):
```
Q1: Run each sprint in its own git worktree? (file-level isolation)  [yes/no]
Q2: Install safety hook blocking rm -rf / and friends in workers?   [yes/no]
Q3: Save globally (all projects) or just this project?              [global/project]
```

Answers persist. Subsequent runs: silent startup, no prompts.

**Per-project override** (escape hatch):
```bash
python3 ~/.claude/skills/autonomous-skill/scripts/user-config.py \
  set mode.worktrees false --scope project --project .
```

**Env var override** (debugging):
```bash
AUTONOMOUS_SPRINT_WORKTREES=0 /autonomous ...  # force off for this run
```

## Precedence

High → low:
1. Env var (`AUTONOMOUS_SPRINT_WORKTREES`, `AUTONOMOUS_WORKER_CAREFUL`)
2. `<project>/.autonomous/config.json`
3. `~/.claude/autonomous/config.json`
4. Legacy `<project>/.autonomous/skill-config.json` (template only)
5. Built-in defaults (all off, template=gstack)

## Why `~/.claude/autonomous/` (not inside the skill dir)

The skill itself lives at `~/.claude/skills/autonomous-skill/` and is a git repo. Putting user data there creates conflicts on `git pull` updates. New location is a sibling of the skill, persists across skill upgrades.

## OWNER.md

Now lives at `~/.claude/autonomous/OWNER.md` (global) by default. The existing `~/.claude/skills/autonomous-skill/OWNER.md` is auto-migrated on first run. `persona.scope=project` in config routes it to `<project>/.autonomous/OWNER.md` instead.

## Schema (config.json)

```json
{
  "version": 1,
  "mode": {
    "worktrees": false,
    "careful_hook": false,
    "template": "gstack"
  },
  "persona": {
    "scope": "global",
    "last_generated": null
  },
  "created_at": "...",
  "updated_at": "..."
}
```

## Integration

| Consumer | How it reads |
|---|---|
| `autonomous/SKILL.md` (Dispatch) | `$(user-config.py get mode.worktrees .)` → `WORKTREE_MODE` var |
| `scripts/dispatch.py` | `_careful_enabled()` shells out to `user-config.py get mode.careful_hook` |
| `scripts/build-sprint-prompt.py` | New resolution chain, legacy `skill-config.json` still supported |
| `scripts/persona.py` | Reads `persona.scope` via importlib import of user-config |

## Test plan

- [x] `bash tests/test_user_config.sh` — 38/38
- [x] `bash tests/test_persona.sh` — 21/21 (sandboxed HOME)
- [x] `bash tests/test_careful_hook.sh` — 97/97 (env-var path still works)
- [x] `bash tests/test_build_sprint_prompt.sh` — 25/25 (legacy skill-config.json still read)
- [x] All 13 suites: 688 passing (test_loop's 8 pre-existing failures still match main)
- [x] Smoke-tested manually: fresh HOME → needs-setup; after setup → configured; env var overrides; project overrides global

Closes the "hidden env var" onboarding friction.