### PR TITLE
feat: experimental flags + JSON Schema + init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to autonomous-skill are documented here.
 
 ## [Unreleased]
 
+### Added (experimental flags + schema)
+- `schemas/autonomous-config.schema.json` — JSON Schema (draft-07) documenting every field in `~/.claude/autonomous/config.json` with per-key descriptions. IDEs pick it up via `$schema` for autocomplete.
+- `user-config.py init` — write a fully-populated sample config (all sections, defaults, `$schema` reference) at global or project scope. Refuses to overwrite existing configs.
+- `experimental` section in config schema with two flags — `vira_worktree` and `parallel_sprints`. Both default to false; setting either on emits a WARNING to stderr on every `check` call. Implementation of these features is tracked for a future PR; the flags themselves are no-ops until then but are documented and persist across restarts.
+- `user-config.py check` now emits `WARNING: experimental flags enabled: ...` to stderr when any experimental flag is on. Stdout stays machine-readable (`configured`/`needs-setup`) for bash callers.
+- All written configs include `"$schema": "..."` reference so editors can validate + autocomplete.
+
+
 ### Added
 - `scripts/user-config.py` — global + project config, replaces scattered env vars as the source of truth for mode toggles. Commands: `check`, `get`, `set`, `setup`, `show`, `paths`. Precedence: env > `<project>/.autonomous/config.json` > `~/.claude/autonomous/config.json` > defaults. Reads legacy `.autonomous/skill-config.json` for back-compat.
 - First-time setup in `autonomous/SKILL.md` — when no global config exists, asks once via `AskUserQuestion` for `worktrees`, `careful_hook`, and `scope` (global/project), persists, never asks again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/timeline.py` — Append-only JSONL session event log at `.autonomous/timeline.jsonl` (session-start, sprint-start, sprint-end, phase-transition, session-end)
 - `scripts/explore-scan.py` — Project scanner: scores 8 exploration dimensions via heuristics
 - `scripts/backlog.py` — Cross-session persistent backlog (progressive disclosure, mkdir locking, max 50 items)
-- `scripts/user-config.py` — Global + project config (mode toggles, template, persona scope). Precedence: env > project > global > defaults. Drives first-time AskUserQuestion setup; persists to `~/.claude/autonomous/config.json` or `<project>/.autonomous/config.json`.
+- `scripts/user-config.py` — Global + project config (mode toggles, template, persona scope, experimental flags). Precedence: env > project > global > defaults. Drives first-time AskUserQuestion setup; persists to `~/.claude/autonomous/config.json` or `<project>/.autonomous/config.json`. Written configs reference `schemas/autonomous-config.schema.json` via `$schema` for IDE autocomplete.
+- `schemas/autonomous-config.schema.json` — JSON Schema (draft-07) documenting the full config shape with per-field descriptions. IDEs use it for autocomplete + validation.
 - `scripts/checkpoint.py` — Human-readable markdown snapshots of session state at `.autonomous/checkpoints/<ts>-<slug>.md` (save/list/latest/show)
 - `scripts/persona.py` — OWNER.md auto-generation from git history + project docs
 - `scripts/loop.py` — Standalone launcher (outside CC's skill system)
@@ -157,7 +158,7 @@ then set `{"template":"<name>"}` in `skill-config.json` (or the project override
 
 ## Testing
 
-688 tests across 13 suites, all pure bash:
+712 tests across 13 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -172,7 +173,7 @@ bash tests/test_timeline.sh     # 63 tests: append-only JSONL log, filters, cond
 bash tests/test_careful_hook.sh # 97 tests: PreToolUse hook pattern matching, adversarial bypasses, dispatch integration, window_name validation
 bash tests/test_checkpoint.sh   # 70 tests: save/list/latest/show, path-traversal rejection, YAML injection resistance, type-unsafe JSON, non-UTF8
 bash tests/test_worktree.sh     # 65 tests: per-sprint worktree CRUD, symlink escape refusal, branch validation, registered-worktree guard, merge-sprint --keep-branch
-bash tests/test_user_config.sh  # 38 tests: config precedence (env > project > global > defaults), legacy migration, path validation, malformed config resilience
+bash tests/test_user_config.sh  # 62 tests: config precedence, legacy migration, malformed config, experimental flags + warnings, init command, $schema reference, schema file integrity
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/schemas/autonomous-config.schema.json
+++ b/schemas/autonomous-config.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Sma1lboy/autonomous-skill/main/schemas/autonomous-config.schema.json",
+  "title": "autonomous-skill config",
+  "description": "Schema for ~/.claude/autonomous/config.json (global) and <project>/.autonomous/config.json (per-project). Precedence at read time: env var > project > global > defaults.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional schema URL for IDE/editor autocomplete and validation."
+    },
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Bump on breaking shape changes."
+    },
+    "mode": {
+      "type": "object",
+      "description": "Stable mode toggles consumed by the skill at startup and during dispatch.",
+      "additionalProperties": false,
+      "properties": {
+        "worktrees": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, each sprint runs in its own .worktrees/sprint-N/ git worktree; the main tree stays on the session branch. Env override: AUTONOMOUS_SPRINT_WORKTREES."
+        },
+        "careful_hook": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, dispatched workers get a PreToolUse hook (scripts/hooks/careful.sh) that blocks catastrophic Bash commands (rm -rf /, mkfs, force-push to main, DROP TABLE, etc.). Env override: AUTONOMOUS_WORKER_CAREFUL."
+        },
+        "template": {
+          "type": "string",
+          "default": "gstack",
+          "description": "Worker-task template name. Ships with 'gstack' (uses /office-hours, /qa, /investigate, blocks /ship) and 'default' (generic). Custom templates live at templates/<name>/template.md."
+        }
+      }
+    },
+    "persona": {
+      "type": "object",
+      "description": "OWNER.md persona configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": ["global", "project"],
+          "default": "global",
+          "description": "'global' places OWNER.md at ~/.claude/autonomous/OWNER.md (shared across projects). 'project' routes it to <project>/.autonomous/OWNER.md."
+        },
+        "last_generated": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "ISO timestamp of the last persona generation. Null until persona.py runs once."
+        }
+      }
+    },
+    "experimental": {
+      "type": "object",
+      "description": "EXPERIMENTAL — behavior under active development, subject to breaking changes. Enable only if you accept the instability.",
+      "additionalProperties": false,
+      "properties": {
+        "vira_worktree": {
+          "type": "boolean",
+          "default": false,
+          "description": "EXPERIMENTAL. Enables the vira worktree execution path. Implementation tracked for a future PR; setting this true currently has no effect beyond surfacing the warning."
+        },
+        "parallel_sprints": {
+          "type": "boolean",
+          "default": false,
+          "description": "EXPERIMENTAL. Enables parallel sprint dispatch with file-overlap guards (V2 worktree mode). When enabled the conductor will plan K independent sprints, dispatch them concurrently, and serialize merges. Implementation tracked for a future PR; setting this true currently has no effect beyond surfacing the warning."
+        }
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this config file was first written."
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Most recent modification timestamp."
+    }
+  }
+}

--- a/scripts/user-config.py
+++ b/scripts/user-config.py
@@ -49,16 +49,36 @@ from typing import Any, NoReturn
 
 VERSION = 1
 
+# Path to the JSON Schema shipped with the skill. Written into config files
+# as "$schema" so VS Code / JSON validators pick it up for autocomplete.
+SCHEMA_URL = (
+    "https://raw.githubusercontent.com/Sma1lboy/autonomous-skill/main/"
+    "schemas/autonomous-config.schema.json"
+)
+
 # Keys that are user-toggleable. Env-var names where applicable.
 ENV_OVERRIDES: dict[str, str] = {
     "mode.worktrees": "AUTONOMOUS_SPRINT_WORKTREES",
     "mode.careful_hook": "AUTONOMOUS_WORKER_CAREFUL",
 }
 
-BOOL_KEYS = {"mode.worktrees", "mode.careful_hook"}
+BOOL_KEYS = {
+    "mode.worktrees",
+    "mode.careful_hook",
+    "experimental.vira_worktree",
+    "experimental.parallel_sprints",
+}
 STRING_KEYS = {"mode.template", "persona.scope"}
 VALID_TEMPLATES = {"gstack", "default"}
 VALID_PERSONA_SCOPES = {"global", "project"}
+
+# Experimental keys surface a stderr warning on every `check` so the user
+# never forgets they're running unstable code. Extend this set when adding
+# new experimental toggles. Also update the JSON Schema.
+EXPERIMENTAL_KEYS = {
+    "experimental.vira_worktree",
+    "experimental.parallel_sprints",
+}
 
 DEFAULTS: dict[str, Any] = {
     "mode": {
@@ -69,6 +89,10 @@ DEFAULTS: dict[str, Any] = {
     "persona": {
         "scope": "global",
         "last_generated": None,
+    },
+    "experimental": {
+        "vira_worktree": False,
+        "parallel_sprints": False,
     },
 }
 
@@ -189,9 +213,31 @@ def is_configured() -> bool:
     return global_config_path().exists()
 
 
+def _enabled_experimental(project: Path | None) -> list[str]:
+    """Return the list of experimental.* keys currently set to true in the
+    effective config (after project/global merge). Used to warn on startup."""
+    cfg = load_effective(project)
+    enabled: list[str] = []
+    for key in EXPERIMENTAL_KEYS:
+        value = _get_nested(cfg, key)
+        if value is True:
+            enabled.append(key)
+    return enabled
+
+
 def cmd_check(args: argparse.Namespace) -> None:
-    """Print 'configured' or 'needs-setup'. Called from SKILL.md startup."""
+    """Print 'configured' or 'needs-setup' to stdout. If any experimental
+    flag is on, also print a single-line WARNING to stderr — stdout stays
+    machine-parseable for bash callers, the warning is a human cue."""
     print("configured" if is_configured() else "needs-setup")
+    project = Path(args.project).resolve() if args.project else None
+    enabled = _enabled_experimental(project)
+    if enabled:
+        print(
+            "WARNING: experimental flags enabled (subject to breaking changes): "
+            + ", ".join(sorted(enabled)),
+            file=sys.stderr,
+        )
 
 
 def _coerce_value(key: str, raw: str) -> Any:
@@ -257,10 +303,15 @@ def _write_at_scope(
         # a project-scope write to shadow keys the user set globally (e.g.,
         # setting mode.worktrees=false at project would also write
         # mode.careful_hook=false and erase the inherited global value).
-        existing = {"version": VERSION, "created_at": now_iso()}
+        existing = {
+            "$schema": SCHEMA_URL,
+            "version": VERSION,
+            "created_at": now_iso(),
+        }
     mutation(existing)
     existing["updated_at"] = now_iso()
     existing.setdefault("version", VERSION)
+    existing.setdefault("$schema", SCHEMA_URL)
     _atomic_write_json(path, existing)
     return path
 
@@ -319,6 +370,43 @@ def cmd_show(args: argparse.Namespace) -> None:
     else:  # effective (default)
         data = load_effective(project)
     print(json.dumps(data, indent=2))
+
+
+def cmd_init(args: argparse.Namespace) -> None:
+    """Write a fully-populated sample config at the chosen scope.
+
+    Unlike `setup` (which only writes the keys the user answered), `init`
+    lays down every known field at its default value with the `$schema`
+    reference. Useful as a manual starting point: users can edit the file
+    with full IDE autocomplete via the schema, without having to memorize
+    the key names.
+
+    Refuses to overwrite an existing config — rename the subcommand to
+    `set` or delete the file if you really want to start over.
+    """
+    project = Path(args.project).resolve() if args.project else None
+    if args.scope == "global":
+        path = global_config_path()
+    else:
+        if project is None:
+            die("--project is required when --scope=project")
+        path = project_config_path(project)
+
+    if path.exists():
+        die(
+            f"config already exists at {path}. Edit it directly or use "
+            "`set`/`setup`; `init` refuses to overwrite."
+        )
+
+    seeded = {
+        "$schema": SCHEMA_URL,
+        "version": VERSION,
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
+    }
+    seeded.update(json.loads(json.dumps(DEFAULTS)))  # deep copy
+    _atomic_write_json(path, seeded)
+    print(f"wrote sample config to {path}")
 
 
 def cmd_paths(args: argparse.Namespace) -> None:
@@ -381,6 +469,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_show.add_argument("--project", default=None)
     p_show.set_defaults(func=cmd_show)
+
+    p_init = sub.add_parser(
+        "init",
+        help="write a fully-populated sample config (all fields, defaults, $schema)",
+    )
+    p_init.add_argument("--scope", choices=["global", "project"], default="global")
+    p_init.add_argument("--project", default=None)
+    p_init.set_defaults(func=cmd_init)
 
     p_paths = sub.add_parser("paths", help="print resolved paths (debug)")
     p_paths.add_argument("--project", default=None)

--- a/tests/test_user_config.sh
+++ b/tests/test_user_config.sh
@@ -213,4 +213,140 @@ echo '["list","not","dict"]' > "$T/.autonomous/config.json"
 OUT=$(HOME="$H" python3 "$UC" get mode.worktrees "$T" 2>&1)
 assert_eq "$OUT" "false" "malformed configs fall through to default"
 
+# ── 12. Experimental flags ──────────────────────────────────────────────
+
+echo ""
+echo "12. Experimental flags"
+
+H=$(sandbox_home)
+T=$(make_project)
+# Defaults: both experimental flags off
+HOME="$H" python3 "$UC" setup --scope global --worktrees on > /dev/null
+VIRA=$(HOME="$H" python3 "$UC" get experimental.vira_worktree "$T")
+PARA=$(HOME="$H" python3 "$UC" get experimental.parallel_sprints "$T")
+assert_eq "$VIRA" "false" "vira_worktree defaults to false"
+assert_eq "$PARA" "false" "parallel_sprints defaults to false"
+
+# Can be set
+HOME="$H" python3 "$UC" set experimental.vira_worktree true --scope global > /dev/null
+VIRA=$(HOME="$H" python3 "$UC" get experimental.vira_worktree "$T")
+assert_eq "$VIRA" "true" "experimental flag set persists"
+
+# Validation: must be bool
+if HOME="$H" python3 "$UC" set experimental.vira_worktree maybe --scope global 2>/dev/null; then
+  fail "non-bool experimental value should be rejected"
+else
+  ok "non-bool experimental value rejected"
+fi
+
+# check emits warning to stderr when any experimental is on
+STDERR=$(HOME="$H" python3 "$UC" check "$T" 2>&1 >/dev/null)
+assert_contains "$STDERR" "experimental flags enabled" "check warns on experimental"
+assert_contains "$STDERR" "vira_worktree" "warning names the enabled flag"
+
+# stdout stays clean (machine-readable)
+STDOUT=$(HOME="$H" python3 "$UC" check "$T" 2>/dev/null)
+assert_eq "$STDOUT" "configured" "stdout unchanged by experimental warning"
+
+# No warning when all experimental flags are off
+HOME="$H" python3 "$UC" set experimental.vira_worktree false --scope global > /dev/null
+STDERR=$(HOME="$H" python3 "$UC" check "$T" 2>&1 >/dev/null)
+assert_not_contains "$STDERR" "experimental" "no warning when no experimental flags on"
+
+# ── 13. $schema reference in written configs ────────────────────────────
+
+echo ""
+echo "13. \$schema reference"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --worktrees on > /dev/null
+CONFIG="$H/.claude/autonomous/config.json"
+assert_file_contains "$CONFIG" "autonomous-config.schema.json" "setup writes \$schema field"
+
+# set also writes $schema if file didn't exist
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" set mode.worktrees true --scope global > /dev/null
+assert_file_contains "$H/.claude/autonomous/config.json" "autonomous-config.schema.json" "set writes \$schema on fresh file"
+
+# ── 14. init command ────────────────────────────────────────────────────
+
+echo ""
+echo "14. init command (sample config)"
+
+H=$(sandbox_home)
+OUT=$(HOME="$H" python3 "$UC" init --scope global)
+assert_contains "$OUT" "wrote sample config" "init prints path"
+
+CONFIG="$H/.claude/autonomous/config.json"
+assert_file_exists "$CONFIG" "init wrote a config"
+# All top-level sections present
+assert_file_contains "$CONFIG" '"mode"' "init seeds mode section"
+assert_file_contains "$CONFIG" '"persona"' "init seeds persona section"
+assert_file_contains "$CONFIG" '"experimental"' "init seeds experimental section"
+assert_file_contains "$CONFIG" '"vira_worktree"' "init lists vira_worktree"
+assert_file_contains "$CONFIG" '"parallel_sprints"' "init lists parallel_sprints"
+assert_file_contains "$CONFIG" "autonomous-config.schema.json" "init includes \$schema"
+
+# init refuses to overwrite
+if HOME="$H" python3 "$UC" init --scope global 2>/dev/null; then
+  fail "init should refuse when config exists"
+else
+  ok "init refuses to clobber existing config"
+fi
+
+# init --scope project requires --project
+H=$(sandbox_home)
+if HOME="$H" python3 "$UC" init --scope project 2>/dev/null; then
+  fail "init --scope project without --project should fail"
+else
+  ok "init --scope project requires --project"
+fi
+
+# init --scope project + --project works
+T=$(make_project)
+HOME="$H" python3 "$UC" init --scope project --project "$T" > /dev/null
+assert_file_exists "$T/.autonomous/config.json" "init writes project config"
+
+# ── 15. Schema file exists and is valid ─────────────────────────────────
+
+echo ""
+echo "15. Schema file integrity"
+
+SCHEMA_FILE="$SCRIPT_DIR/../schemas/autonomous-config.schema.json"
+assert_file_exists "$SCHEMA_FILE" "schema file present"
+
+# Valid JSON
+VALID=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$SCHEMA_FILE'))
+    assert d.get('title') == 'autonomous-skill config'
+    assert 'mode' in d.get('properties', {})
+    assert 'experimental' in d.get('properties', {})
+    assert 'vira_worktree' in d['properties']['experimental'].get('properties', {})
+    assert 'parallel_sprints' in d['properties']['experimental'].get('properties', {})
+    print('ok')
+except Exception as e:
+    print(f'fail: {e}', file=sys.stderr)
+    sys.exit(1)
+")
+assert_eq "$VALID" "ok" "schema documents mode + experimental sections"
+
+# Schema matches what user-config.py writes
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" init --scope global > /dev/null
+python3 -c "
+import json
+schema = json.load(open('$SCHEMA_FILE'))
+config = json.load(open('$H/.claude/autonomous/config.json'))
+# Every top-level property in the written config should be in schema.properties
+schema_props = set(schema.get('properties', {}).keys())
+config_keys = set(config.keys())
+missing = config_keys - schema_props
+assert not missing, f'config has keys not in schema: {missing}'
+print('ok')
+" > /tmp/schema-check.out
+assert_eq "$(cat /tmp/schema-check.out)" "ok" "every config key is documented in schema"
+rm -f /tmp/schema-check.out
+
 print_results


### PR DESCRIPTION
## Summary

Two additions to `user-config.py`:

1. **Experimental feature flag infrastructure** — new `experimental` section with two reserved flags (`vira_worktree`, `parallel_sprints`). Flags persist, documented in schema, emit a stderr WARNING when on. Implementations of the features themselves are tracked for a future PR.

2. **JSON Schema for the entire config** — `schemas/autonomous-config.schema.json` (draft-07) with per-key descriptions. All config writes now include a `$schema` field so VS Code and other editors provide autocomplete + validation out of the box.

Plus a new `user-config.py init` command that writes a fully-populated sample config at global or project scope (all sections, defaults, `$schema` reference) — useful as a manual starting point when users want to see everything they can configure.

## Experimental flags

```json
"experimental": {
  "vira_worktree": false,       // EXPERIMENTAL worktree execution path
  "parallel_sprints": false     // EXPERIMENTAL parallel sprint dispatch + file-overlap
}
```

Behavior when on:
- `user-config.py check` emits `WARNING: experimental flags enabled: experimental.vira_worktree, ...` to stderr every call
- Stdout stays `configured`/`needs-setup` (machine-readable for bash)
- Feature itself is a no-op for now — PR to follow

This lets us land the config surface today and iterate on the implementation in isolation, without merging half-baked code behind silent flags.

## JSON Schema

Shipped at `schemas/autonomous-config.schema.json`. Every top-level section and key has a `description` field explaining what it does and linking back to the relevant env var overrides.

Written configs reference it via `$schema`:
```json
{
  "$schema": "https://raw.githubusercontent.com/Sma1lboy/autonomous-skill/main/schemas/autonomous-config.schema.json",
  "version": 1,
  "mode": { ... }
}
```

VS Code picks this up automatically — users get autocomplete and inline validation when hand-editing the config.

## `init` vs `setup` vs `set`

| Command | What it writes | When to use |
|---|---|---|
| `init` | Full sample: every section with defaults | "I want to see all my options" |
| `setup` | Only the keys you specify | First-time AskUserQuestion flow |
| `set K V` | One key | Ad-hoc tweak |

`init` refuses to overwrite to prevent accidental wipes.

## Test plan

- [x] `bash tests/test_user_config.sh` — 62/62 (24 new tests)
- [x] `python3 -m compileall scripts` clean
- [x] 712 tests across 13 suites green (test_loop's 8 pre-existing failures still match main; test_checkpoint has a known same-second flaky test)
- [x] Schema file is valid JSON, documents every top-level key that appears in written configs
- [x] `init` writes a complete config; refuses to overwrite
- [x] Experimental flag default false, can be set, warning fires on check