### PR TITLE
docs: rename to autonomous in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![logo](assets/logo.svg)
 
-# autonomous-skill
+# autonomous
 
 > *"You sleep. It ships."*
 
@@ -17,7 +17,7 @@ You close your laptop at midnight. 47 TODOs in your backlog.<br>
 You open it at 8am. 38 of them are done, tested, committed, on a clean branch.<br>
 Total cost: $4.20. No meetings required.<br>
 
-**That's autonomous-skill.**
+**That's autonomous.**
 
 A self-driving project agent for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 Drop it into any git repo, run `/autonomous`, go to sleep.
@@ -37,7 +37,7 @@ Optional: [tmux](https://github.com/tmux/tmux) (visible worker windows), [jq](ht
 Paste this into Claude Code:
 
 ```
-Install autonomous-skill: git clone https://github.com/Sma1lboy/autonomous-skill.git ~/.claude/skills/autonomous-skill && cd ~/.claude/skills/autonomous-skill && ./setup
+Install autonomous: git clone https://github.com/Sma1lboy/autonomous.git ~/.claude/skills/autonomous-skill && cd ~/.claude/skills/autonomous-skill && ./setup
 ```
 
 That's it. Open any git repo and run `/autonomous` or `/quickdo`.


### PR DESCRIPTION
## Summary
- GitHub repo renamed `Sma1lboy/autonomous-skill` → `Sma1lboy/autonomous` (via `gh repo rename`)
- README title + narrative now say "autonomous"
- Clone URL's `github.com` portion updated to new repo name

## Scope deliberately minimal
Only the README public-facing strings changed. Internal paths, docstrings, SKILL.md `name:` field, install directory (`~/.claude/skills/autonomous-skill/`), `.autonomous-skill` marker, cache dir, and schema \`\$id\` URL are **unchanged**.

GitHub's 301 redirects keep every old URL working (clone, raw content, API), so the internal-string churn would be cosmetic at best and risks breaking existing installs at worst.

The install dir stays as `autonomous-skill` (not `autonomous`) because `setup` registers `/autonomous` as an alias symlink dir at `~/.claude/skills/autonomous/` — renaming the repo checkout to the same path would collide.

## Test plan
- [ ] \`gh repo view Sma1lboy/autonomous\` shows the renamed repo
- [ ] Existing installs continue to work (update-check hits the same URL via GH redirect)
- [ ] \`bash tests/test_user_config.sh\` — 72/72 pass locally
- [ ] \`python3 -m compileall scripts\` — clean