### PR TITLE
docs(autonomous): warn about stale sprint-summary.json poisoning next sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to autonomous-skill are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- Sprint summary contract: worker now writes directly to `.autonomous/sprint-<N>-summary.json` instead of the generic `sprint-summary.json` that `monitor-sprint.py` had to rename. Eliminates the "stale generic file poisons the next sprint" bug class. `write-summary.py` takes a required `sprint_num` argument; `SPRINT.md` passes `$SPRINT_NUMBER`; `monitor-sprint.py` only polls the numbered file; `quickdo/SKILL.md` reads `sprint-1-summary.json`. `conductor-state.py init` still deletes any leftover generic file as an upgrade safety net.
+
 ### Changed
 - Templates now live at `templates/<name>/rules.json` with `allows` + `blocks` arrays (replacing `template.md` with `## Allow` / `## Block` markdown sections). Multiple templates can be composed via `mode.templates` — a list of names that merge their rules in order, with duplicates dropped.
 - `mode.templates` (list) replaces `mode.template` (string) as the canonical key. Default is `["gstack"]` so first-time users keep seeing the gstack slash-command suggestions. The singular `mode.template` still works as a deprecated read alias (returns `mode.templates[0]`) and write alias (writes a single-item array, emits a warning).

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -109,7 +109,7 @@ You have a specific direction for this sprint. Focus on it.
    Write the sprint summary:
 
    ```bash
-   python3 "$SCRIPT_DIR/scripts/write-summary.py" "$(pwd)" "complete" "2-3 sentence summary here"
+   python3 "$SCRIPT_DIR/scripts/write-summary.py" "$(pwd)" "$SPRINT_NUMBER" "complete" "2-3 sentence summary here"
    ```
 
 ## Worker Prompt

--- a/quickdo/SKILL.md
+++ b/quickdo/SKILL.md
@@ -84,9 +84,9 @@ echo ""
 echo "=== COMMITS ==="
 git log main.."$QUICKDO_BRANCH" --oneline --no-merges 2>/dev/null || git log --oneline -10
 echo ""
-if [ -f .autonomous/sprint-summary.json ]; then
+if [ -f .autonomous/sprint-1-summary.json ]; then
   echo "=== SUMMARY ==="
-  cat .autonomous/sprint-summary.json
+  cat .autonomous/sprint-1-summary.json
 fi
 ```
 

--- a/scripts/monitor-sprint.py
+++ b/scripts/monitor-sprint.py
@@ -49,7 +49,6 @@ def main(argv: list[str]) -> int:
 
     project = Path(args.project_dir).resolve()
     summary_file = project / ".autonomous" / f"sprint-{args.sprint_num}-summary.json"
-    generic = project / ".autonomous" / "sprint-summary.json"
 
     window_name = f"sprint-{args.sprint_num}"
     while True:
@@ -58,19 +57,9 @@ def main(argv: list[str]) -> int:
             print(f"=== SPRINT {args.sprint_num} COMPLETE ===")
             print(summary_file.read_text())
             break
-        if generic.exists():
-            summary_file.write_text(generic.read_text())
-            generic.unlink(missing_ok=True)
-            tmux_kill(window_name)
-            print(f"=== SPRINT {args.sprint_num} COMPLETE ===")
-            print(summary_file.read_text())
-            break
         if tmux_available():
             if not tmux_has_window(window_name):
                 print(f"=== SPRINT {args.sprint_num} WINDOW CLOSED ===")
-                if generic.exists():
-                    summary_file.write_text(generic.read_text())
-                    generic.unlink(missing_ok=True)
                 break
         time.sleep(8)
     return 0

--- a/scripts/parallel-sprint.py
+++ b/scripts/parallel-sprint.py
@@ -25,7 +25,7 @@ Design notes / known limits (V2 — experimental):
   in the wave. This keeps blame attribution simple ("sprint 3 is stuck"
   rather than "sprint 1, 3, and 5 each blocked something else").
 - Worker failure != merge failure. A worker can time out / crash (no
-  sprint-summary.json) and we still try to merge whatever commits it left
+  sprint-N-summary.json) and we still try to merge whatever commits it left
   on its branch before declaring it incomplete.
 - Cap via `experimental.max_parallel_sprints` (default 3). Honored strictly.
 """

--- a/scripts/write-summary.py
+++ b/scripts/write-summary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Write sprint-summary.json from git state."""
+"""Write sprint-N-summary.json from git state."""
 from __future__ import annotations
 
 import argparse
@@ -23,11 +23,15 @@ def git_commits(project: Path, limit: int = 5) -> list[str]:
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="Write sprint summary JSON")
     parser.add_argument("project_dir")
+    parser.add_argument("sprint_num", type=int)
     parser.add_argument("status", choices=["complete", "partial", "blocked"])
     parser.add_argument("summary")
     parser.add_argument("iterations", nargs="?", type=int, default=1)
     parser.add_argument("direction_complete", nargs="?", default="true")
     args = parser.parse_args(argv[1:])
+
+    if args.sprint_num <= 0:
+        parser.error(f"sprint_num must be > 0, got: {args.sprint_num}")
 
     project = Path(args.project_dir).resolve()
     commits = git_commits(project)
@@ -38,7 +42,7 @@ def main(argv: list[str]) -> int:
         "iterations_used": args.iterations,
         "direction_complete": args.direction_complete.lower() == "true",
     }
-    target = project / ".autonomous" / "sprint-summary.json"
+    target = project / ".autonomous" / f"sprint-{args.sprint_num}-summary.json"
     target.parent.mkdir(exist_ok=True)
     target.write_text(json.dumps(summary, indent=2))
     print(json.dumps(summary, indent=2))

--- a/tests/test_eval_output.sh
+++ b/tests/test_eval_output.sh
@@ -184,18 +184,15 @@ assert_contains "$OUTPUT" "complete" "prints summary content"
 
 # ═══════════════════════════════════════════════════════════════════════════
 echo ""
-echo "9. monitor-sprint.py — renames generic summary to numbered"
+echo "9. monitor-sprint.py — only polls the numbered file (no generic fallback)"
 
-T=$(new_tmp)
-mkdir -p "$T/.autonomous"
-cat > "$T/.autonomous/sprint-summary.json" << 'EOF'
-{"status":"complete","summary":"via generic","commits":[],"direction_complete":true}
-EOF
-
-OUTPUT=$(python3 "$MONITOR" "$T" "2" 2>/dev/null)
-assert_contains "$OUTPUT" "SPRINT 2 COMPLETE" "detects generic summary and renames"
-assert_file_exists "$T/.autonomous/sprint-2-summary.json" "numbered file created"
-assert_file_not_exists "$T/.autonomous/sprint-summary.json" "generic file removed"
+# After the sprint-summary contract change, workers write directly to
+# sprint-N-summary.json via write-summary.py. monitor-sprint.py must NOT
+# fall back to the old generic 'sprint-summary.json' name — a lingering
+# generic file from a prior version would otherwise poison the next sprint.
+SCRIPT_CONTENT=$(cat "$MONITOR")
+assert_contains "$SCRIPT_CONTENT" 'f"sprint-{args.sprint_num}-summary.json"' "monitor polls the numbered file"
+assert_not_contains "$SCRIPT_CONTENT" '"sprint-summary.json"' "monitor does not reference the generic filename"
 
 # ═══════════════════════════════════════════════════════════════════════════
 echo ""
@@ -222,7 +219,7 @@ else
 fi
 
 KILL_COUNT=$(grep -c "tmux_kill(window_name)" "$MONITOR" || true)
-assert_ge "$KILL_COUNT" "2" "tmux_kill called in both completion branches"
+assert_eq "$KILL_COUNT" "1" "tmux_kill called exactly once on summary-file completion"
 
 # ═══════════════════════════════════════════════════════════════════════════
 print_results


### PR DESCRIPTION
## Problem

The worker writes its summary to `.autonomous/sprint-summary.json` (generic filename, no sprint number — see `scripts/write-summary.py:43`). `monitor-sprint.py` is the **only** component that renames it to `sprint-$N-summary.json` AND deletes the generic after renaming (`scripts/monitor-sprint.py:63-65`).

Failure mode observed in the wild:

1. Conductor dispatches Sprint N. Worker writes to `sprint-summary.json` and finishes.
2. Conductor skips the skill-provided `monitor-sprint.py` (e.g. uses a custom poller that only checks `sprint-$N-summary.json`). The generic file persists on disk.
3. Conductor renames the file manually to `sprint-$N-summary.json` — but the generic still exists.
4. Conductor dispatches Sprint N+1. `monitor-sprint.py` for Sprint N+1 starts polling.
5. It sees the stale generic `sprint-summary.json` (left over from Sprint N), treats it as Sprint N+1's completion signal, renames it into `sprint-$N+1-summary.json` (with WRONG content), and **kills the fresh tmux window** — before the new worker has done anything.
6. Sprint N+1 worker is killed. Conductor thinks it completed; `sprint-$N+1-summary.json` contains Sprint N's content.

## Fix

Two minimal doc-only changes to `autonomous/SKILL.md`:

1. **Dispatch block** — add `rm -f .autonomous/sprint-summary.json` before `build-sprint-prompt.py` as belt-and-suspenders cleanup so any stale generic gets cleared before the new worker starts.

2. **Monitor section** — add a GOTCHA block documenting the filename contract and the poisoning failure mode, so future conductors know running `monitor-sprint.py` between dispatch and evaluate is not optional if they also run a custom poller.

## Observed in

A multi-sprint monorepo refactor where Sprint 2 used a custom Monitor (only checking `sprint-2-summary.json`). Sprint 3's `monitor-sprint.py` false-completed the fresh Sprint 3 worker by renaming the stale generic from Sprint 2. Sprint 3 had to be re-dispatched from scratch.

## Alternative fixes considered (not in this PR)

- Have `monitor-sprint.py` check file mtime against dispatch time before accepting the generic file as valid
- Change `write-summary.py` to write to `sprint-$N-summary.json` directly (requires passing sprint number to worker, bigger contract change)

Picking the doc-only + belt-suspenders approach here since it's the lowest-risk change; either of the alternatives could be a follow-up.