### PR TITLE
feat(autonomous): add dev mode for self-improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to autonomous-skill are documented here.
 
 ## [Unreleased]
 
+### Added
+- Dev mode (`mode.profile=dev`) — opt-in conductor profile that appends `modes/dev/prompt.md` to the Conductor startup, giving it permission to fix bugs in the autonomous-skill tool itself. Flow: isolated worktree (never edits the live install) → TDD fix → verification gate (`bash tests/test_*.sh` + `python3 -m compileall` + smoke-test) → `gh pr create` for human review (never auto-merge). Dev mode force-enables `mode.worktrees` as a safety rail so a broken fix can't corrupt `~/.claude/skills/autonomous-skill`.
+- `scripts/user-config.py`: `mode.profile` config key with enum `["default","dev"]`, default `"default"`; `--profile` flag on `setup`; `AUTONOMOUS_MODE_PROFILE` env override; `load_effective()` rail that force-sets `mode.worktrees=true` when profile=dev.
+- `schemas/autonomous-config.schema.json`: documents `mode.profile` with enum, default, and description of the safety rail.
+- `autonomous/SKILL.md` Startup: reads `mode.profile`, exports `AUTONOMOUS_SKILL_DIR=$SCRIPT_DIR`, and emits the addendum wrapped in `=== DEV MODE ADDENDUM ===` markers when profile=dev (silent otherwise).
+- `tests/test_dev_mode.sh` (19 tests): prompt content markers, Startup emission on/off by profile, env-override path, `AUTONOMOUS_SKILL_DIR` export.
+- `tests/test_user_config.sh` (+26 tests): `mode.profile` default/set/invalid/env-override/force-worktrees/schema coverage.
+
+### Changed
+
 
 ## [0.8.0] — 2026-04-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Conductor (SKILL.md, user's CC session)
 - `explore-ralph-loop/SKILL.md` — Explore Ralph Loop: detects toolchain, captures execute-verify-fix patterns as reusable skills
 - `scripts/register-ralph-loops.sh` — Dynamic scanner: symlinks ralph-loop-skills/ to ~/.claude/skills/
 - `ralph-loop-skills/` — Generated loop skills (gitignored, per-user)
+- `modes/dev/prompt.md` — Dev-mode addendum appended to the Conductor prompt when `mode.profile=dev`. Permits the Conductor to fix bugs in autonomous-skill itself via an isolated worktree, bash-test + smoke-test verification gate, and a human-review PR (no auto-merge). Dev mode force-enables `mode.worktrees` as a safety rail. Enable via `python3 scripts/user-config.py setup --profile dev` or env `AUTONOMOUS_MODE_PROFILE=dev`.
 
 ## How it works
 
@@ -163,7 +164,7 @@ To add a new template: create `templates/<name>/rules.json` with `allows` and
 
 ## Testing
 
-739 tests across 14 suites, all pure bash:
+785 tests across 15 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -178,8 +179,9 @@ bash tests/test_timeline.sh     # 63 tests: append-only JSONL log, filters, cond
 bash tests/test_careful_hook.sh # 97 tests: PreToolUse hook pattern matching, adversarial bypasses, dispatch integration, window_name validation
 bash tests/test_checkpoint.sh   # 70 tests: save/list/latest/show, path-traversal rejection, YAML injection resistance, type-unsafe JSON, non-UTF8
 bash tests/test_worktree.sh     # 65 tests: per-sprint worktree CRUD, symlink escape refusal, branch validation, registered-worktree guard, merge-sprint --keep-branch
-bash tests/test_user_config.sh  # 62 tests: config precedence, legacy migration, malformed config, experimental flags + warnings, init command, $schema reference, schema file integrity
+bash tests/test_user_config.sh  # 88 tests: config precedence, legacy migration, malformed config, experimental flags + warnings, init command, $schema reference, schema file integrity, mode.profile (default/dev enum + validation + force-worktrees rail + env override)
 bash tests/test_parallel_sprint.sh # 27 tests: V2 parallel orchestrator — gating, validation, E2E wave dispatch + serial merge + worktree teardown, max-parallel sources
+bash tests/test_dev_mode.sh     # 19 tests: modes/dev/prompt.md content + SKILL.md Startup addendum emission (dev vs default profile, env override, AUTONOMOUS_SKILL_DIR export)
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/autonomous/SKILL.md
+++ b/autonomous/SKILL.md
@@ -26,6 +26,18 @@ echo "CONFIG_STATUS=$CONFIG_STATUS"
 eval "$(python3 "$SCRIPT_DIR/scripts/user-config.py" experimental "$(pwd)" 2>/dev/null || true)"
 python3 "$SCRIPT_DIR/scripts/persona.py" "$(pwd)" >/dev/null 2>&1
 python3 "$SCRIPT_DIR/scripts/startup.py" "$(pwd)"
+
+# Conductor profile. "dev" appends modes/dev/prompt.md (permission to fix
+# bugs in the autonomous-skill tool itself). Default is a no-op.
+MODE_PROFILE=$(python3 "$SCRIPT_DIR/scripts/user-config.py" get mode.profile "$(pwd)" 2>/dev/null || echo "default")
+export AUTONOMOUS_SKILL_DIR="$SCRIPT_DIR"
+if [ "$MODE_PROFILE" = "dev" ] && [ -f "$SCRIPT_DIR/modes/dev/prompt.md" ]; then
+  echo ""
+  echo "=== DEV MODE ADDENDUM (mode.profile=dev) ==="
+  cat "$SCRIPT_DIR/modes/dev/prompt.md"
+  echo "=== END DEV MODE ADDENDUM ==="
+  echo ""
+fi
 ```
 
 If the startup block outputs `UPDATE_AVAILABLE <old> <new>`, tell the user:

--- a/modes/dev/prompt.md
+++ b/modes/dev/prompt.md
@@ -1,0 +1,166 @@
+# Dev Mode — self-improvement addendum
+
+This addendum is appended to the Conductor prompt when `mode.profile=dev`.
+It gives the Conductor permission to fix bugs in the autonomous-skill tool
+itself — in addition to whatever the user asked you to do on their project.
+
+You are still the Conductor of the user's project. Dev mode is an extra
+hat, not a replacement. The user's mission stays the primary objective.
+
+---
+
+## When to raise a skill-fix sprint
+
+While running the user's project, you may notice the tool misbehaving:
+- Repeatable glitches in Conductor/Sprint Master/Worker coordination
+- Race conditions, stale state, or logic bugs in `scripts/`
+- Template rendering bugs, broken comms protocol, bad env wiring
+- Drift between `SKILL.md` / scripts / tests / docs
+- A reproducible failure that forced you to work around the tool
+
+When you see one:
+1. Keep going on the user's sprint first — do not abandon it mid-flight.
+2. At a natural boundary (between sprints), spin out a **side sprint**
+   that targets the skill repo instead of the user project.
+3. Resume the user's work after the side sprint lands (or is abandoned).
+
+Skill-fix sprints are **opportunistic**, not mandatory. If the user's
+mission is urgent or the skill bug is tiny, note it in the backlog and
+move on.
+
+## Cross-repo flow
+
+Dev mode works across two repos: the user's project (where you normally
+run) and the autonomous-skill install (`~/.claude/skills/autonomous-skill`
+or wherever `SCRIPT_DIR` points). The fix happens in the skill repo; the
+user's sprint branch is untouched.
+
+### 1. Locate the skill repo
+
+```bash
+AUTONOMOUS_SKILL_DIR="$SCRIPT_DIR"
+[ -d "$AUTONOMOUS_SKILL_DIR/.git" ] || {
+  echo "skill repo not a git checkout at $AUTONOMOUS_SKILL_DIR — abort dev-mode fix" >&2
+  exit 0  # silently skip, do not fail the user's sprint
+}
+```
+
+### 2. Open an isolated worktree (never edit the live install directly)
+
+```bash
+FIX_SLUG="<short-kebab-describing-the-bug>"
+FIX_BRANCH="fix/dev-mode-$(date +%s)-$FIX_SLUG"
+(
+  cd "$AUTONOMOUS_SKILL_DIR"
+  git fetch origin main
+  # Always branch off fresh origin/main so the fix doesn't inherit
+  # whatever state the install is sitting on.
+  git worktree add ".worktrees/dev-mode-fix" -b "$FIX_BRANCH" origin/main
+)
+FIX_TREE="$AUTONOMOUS_SKILL_DIR/.worktrees/dev-mode-fix"
+```
+
+Invariant: **never edit files directly under `$AUTONOMOUS_SKILL_DIR`** in
+dev mode. All edits go into `$FIX_TREE`. Corrupting the live install
+would brick the next `/autonomous-skill` invocation.
+
+### 3. Write the failing test first, then implement the fix
+
+```bash
+cd "$FIX_TREE"
+# Add or extend a test in tests/test_*.sh that reproduces the bug.
+# Run only that suite; confirm it fails.
+bash tests/test_<affected>.sh     # expect RED
+# Implement the minimal fix in scripts/ / SKILL.md / SPRINT.md / templates/
+bash tests/test_<affected>.sh     # expect GREEN
+```
+
+### 4. Verification gate — ALL must pass before PR
+
+Run in order. Stop at the first failure (don't mask errors with `|| true`):
+
+```bash
+# 4a. Python syntax
+python3 -m compileall scripts
+
+# 4b. Full bash test suite — fast-fail layer
+for t in tests/test_*.sh; do
+  bash "$t" || { echo "FAIL: $t"; exit 1; }
+done
+
+# 4c. Smoke test — end-to-end pipeline (slow, exercises the full
+# Conductor -> Master -> Worker chain). Only runs if the relevant skill
+# exists in this worktree.
+if [ -d ".claude/skills/smoke-test" ]; then
+  # Delegate to a subagent so smoke-test noise stays out of the main
+  # Conductor context. Subagent should report SUMMARY: N/M passed.
+  # (See CLAUDE.md "Sandbox verification" for the prompt shape.)
+  :
+fi
+```
+
+If any step fails: **do not open a PR**. Leave the worktree for
+inspection, write a sprint summary that flags the failure, and move on.
+
+### 5. Open a PR (never auto-merge)
+
+```bash
+cd "$FIX_TREE"
+git push -u origin "$FIX_BRANCH"
+gh pr create \
+  --base main \
+  --title "fix(<area>): <one-line summary>" \
+  --body "$(cat <<EOF
+## Summary
+<what was broken, what the fix does, in 2-3 sentences>
+
+## Repro
+<steps / symptom, if non-obvious>
+
+## Test plan
+- [ ] tests/test_<affected>.sh covers the bug
+- [ ] Full bash test suite passes
+- [ ] python3 -m compileall scripts clean
+- [ ] Smoke test run (if applicable)
+
+🤖 Opened by dev-mode conductor (mode.profile=dev)
+EOF
+)"
+```
+
+### 6. Cleanup + return to user's sprint
+
+```bash
+cd "$AUTONOMOUS_SKILL_DIR"
+git worktree remove ".worktrees/dev-mode-fix" --force
+# Branch stays on origin — human will merge the PR.
+```
+
+Then resume the user's planned next sprint as usual. Note in the user's
+session summary that you sidetracked for a skill fix and link the PR URL
+so it's auditable.
+
+## Boundaries
+
+- **Never** force-push to `main` on the skill repo.
+- **Never** merge the PR yourself, even if all checks are green. Human
+  review is non-negotiable — dev mode is an accelerator, not an autopilot.
+- **Never** edit files under `$AUTONOMOUS_SKILL_DIR` directly; only in
+  the worktree under `$FIX_TREE`.
+- **Never** skip the verification gate to push faster. A broken fix
+  merged is worse than no fix.
+- **Never** modify `VERSION`, `CHANGELOG.md`, or any release plumbing in
+  a dev-mode sprint. Those are human-owned. Let the reviewer land them.
+- **Never** recurse: dev-mode fix sprints themselves must not spawn
+  further dev-mode fix sprints. One level deep, always.
+
+## When in doubt, skip
+
+If the suspected skill bug is:
+- Not reliably reproducible
+- Cosmetic only
+- Requires architectural changes
+- Touches release plumbing
+
+…just write it to the backlog (`scripts/backlog.py add ...`) and continue
+the user's work. A human can triage later.

--- a/schemas/autonomous-config.schema.json
+++ b/schemas/autonomous-config.schema.json
@@ -35,6 +35,12 @@
           "items": { "type": "string" },
           "default": ["gstack"],
           "description": "Worker-task templates to compose into each sprint prompt. Default ['gstack'] opts into the gstack slash-command set; replace with ['default'] for generic guidance, or stack multiple (e.g., ['gstack','custom']) to merge their allow/block rules. Names containing '/', '\\', or leading with '.' are rejected as path-traversal attempts."
+        },
+        "profile": {
+          "type": "string",
+          "enum": ["default", "dev"],
+          "default": "default",
+          "description": "Conductor profile. 'default' runs the normal project-directed flow. 'dev' additionally injects modes/dev/prompt.md — giving the conductor permission to fix bugs in the autonomous-skill tool itself via an isolated worktree, bash+smoke-test verification gate, and a human-review PR. Dev profile force-enables mode.worktrees (safety rail: a broken fix cannot corrupt the live install). Env override: AUTONOMOUS_MODE_PROFILE."
         }
       }
     },

--- a/scripts/user-config.py
+++ b/scripts/user-config.py
@@ -67,6 +67,7 @@ SCHEMA_URL = (
 ENV_OVERRIDES: dict[str, str] = {
     "mode.worktrees": "AUTONOMOUS_SPRINT_WORKTREES",
     "mode.careful_hook": "AUTONOMOUS_WORKER_CAREFUL",
+    "mode.profile": "AUTONOMOUS_MODE_PROFILE",
 }
 
 BOOL_KEYS = {
@@ -75,9 +76,13 @@ BOOL_KEYS = {
     "experimental.vira_worktree",
     "experimental.parallel_sprints",
 }
-STRING_KEYS = {"persona.scope"}
+STRING_KEYS = {"persona.scope", "mode.profile"}
 LIST_KEYS = {"mode.templates"}
 VALID_PERSONA_SCOPES = {"global", "project"}
+# Profile is a one-line switch that tells SKILL.md whether to inject the
+# dev-mode addendum. Extend cautiously — each new profile should have a
+# matching modes/<name>/prompt.md or it's a no-op.
+VALID_PROFILES = {"default", "dev"}
 
 # Experimental keys surface a stderr warning on every `check` so the user
 # never forgets they're running unstable code. Extend this set when adding
@@ -92,6 +97,11 @@ DEFAULTS: dict[str, Any] = {
         "worktrees": False,
         "careful_hook": False,
         "templates": ["gstack"],
+        # "default" = normal conductor; "dev" = conductor may also fix
+        # bugs in the autonomous-skill tool itself via cross-repo PR flow.
+        # Dev mode force-enables worktrees (see load_effective) so a broken
+        # fix can't brick the live install.
+        "profile": "default",
     },
     "persona": {
         "scope": "global",
@@ -252,6 +262,22 @@ def load_effective(project: Path | None) -> dict[str, Any]:
             if legacy:
                 merged.setdefault("mode", {})["templates"] = [legacy]
 
+    # Env override for mode.profile — applied here (not only in cmd_get) so
+    # that the dev-mode force-worktrees rail below sees env overrides too.
+    # Other env overrides stay in cmd_get to avoid surprising callers that
+    # rely on load_effective returning persisted values only.
+    profile_env = os.environ.get("AUTONOMOUS_MODE_PROFILE")
+    if profile_env and profile_env in VALID_PROFILES:
+        merged.setdefault("mode", {})["profile"] = profile_env
+
+    # Dev-mode safety rail: force worktrees on. A broken fix from the
+    # dev-mode conductor must not be able to corrupt the live install; the
+    # worktree isolates edits on a separate branch and a separate path.
+    # User can still override via AUTONOMOUS_SPRINT_WORKTREES=false, since
+    # bool env overrides are applied at cmd_get time (explicit escape hatch).
+    if merged.get("mode", {}).get("profile") == "dev":
+        merged.setdefault("mode", {})["worktrees"] = True
+
     return merged
 
 
@@ -303,6 +329,10 @@ def _coerce_value(key: str, raw: str) -> Any:
         if raw not in VALID_PERSONA_SCOPES:
             die(f"invalid scope: {raw} (use global|project)")
         return raw
+    if key == "mode.profile":
+        if raw not in VALID_PROFILES:
+            die(f"invalid profile: {raw} (use {'|'.join(sorted(VALID_PROFILES))})")
+        return raw
     if key in STRING_KEYS:
         return raw
     die(f"unknown key: {key}")
@@ -324,9 +354,19 @@ def cmd_get(args: argparse.Namespace) -> None:
     # Env override wins
     env_name = ENV_OVERRIDES.get(key)
     if env_name and env_name in os.environ and os.environ[env_name]:
-        parsed = _parse_bool_env(os.environ[env_name])
-        if parsed is not None:
-            print("true" if parsed else "false")
+        raw = os.environ[env_name]
+        if key in BOOL_KEYS:
+            parsed = _parse_bool_env(raw)
+            if parsed is not None:
+                print("true" if parsed else "false")
+                return
+        elif key == "mode.profile":
+            if raw in VALID_PROFILES:
+                print(raw)
+                return
+            # Invalid env value — ignore, fall through to config
+        elif key in STRING_KEYS:
+            print(raw)
             return
 
     # Deprecated read alias: `mode.template` returns the first element of
@@ -412,6 +452,8 @@ def cmd_setup(args: argparse.Namespace) -> None:
         die(f"invalid --worktrees: {args.worktrees}")
     if args.careful and careful is None:
         die(f"invalid --careful: {args.careful}")
+    if args.profile and args.profile not in VALID_PROFILES:
+        die(f"invalid --profile: {args.profile} (use {'|'.join(sorted(VALID_PROFILES))})")
 
     def mutate(cfg: dict[str, Any]) -> None:
         if worktrees is not None:
@@ -424,6 +466,8 @@ def cmd_setup(args: argparse.Namespace) -> None:
             # Legacy alias: singular --template → one-item templates array
             single = _coerce_value("mode.templates", args.template)
             _set_nested(cfg, "mode.templates", single)
+        if args.profile:
+            _set_nested(cfg, "mode.profile", args.profile)
         if args.persona_scope:
             if args.persona_scope not in VALID_PERSONA_SCOPES:
                 die(f"invalid --persona-scope: {args.persona_scope}")
@@ -578,6 +622,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         choices=list(VALID_PERSONA_SCOPES),
         help="where OWNER.md lives (default global)",
+    )
+    p_setup.add_argument(
+        "--profile",
+        default=None,
+        choices=sorted(VALID_PROFILES),
+        help="conductor profile: 'default' or 'dev' "
+        "(dev unlocks self-improvement flow + force-enables worktrees)",
     )
     p_setup.set_defaults(func=cmd_setup)
 

--- a/tests/test_dev_mode.sh
+++ b/tests/test_dev_mode.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Integration tests for mode.profile=dev:
+#   - modes/dev/prompt.md has the required markers (worktree, gate, PR, no auto-merge)
+#   - autonomous/SKILL.md Startup actually emits the addendum when profile=dev
+#     and stays silent when profile=default
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$SCRIPT_DIR/.."
+UC="$REPO/scripts/user-config.py"
+PROMPT="$REPO/modes/dev/prompt.md"
+SKILL="$REPO/autonomous/SKILL.md"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_dev_mode.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+sandbox_home() {
+  local h
+  h=$(new_tmp)
+  echo "$h"
+}
+
+# Extract the Startup ```bash block from autonomous/SKILL.md once up front
+# so each sub-test can source the same body with a pinned SCRIPT_DIR.
+extract_startup() {
+  SKILL_FILE="$SKILL" python3 -c '
+import os, re, pathlib
+txt = pathlib.Path(os.environ["SKILL_FILE"]).read_text()
+m = re.search(r"## Startup\s*\n\s*```bash\n(.*?)\n```", txt, re.DOTALL)
+print(m.group(1) if m else "")
+'
+}
+
+# ── 1. modes/dev/prompt.md exists and has required markers ───────────────
+
+echo ""
+echo "1. modes/dev/prompt.md exists and covers the flow"
+assert_file_exists "$PROMPT" "modes/dev/prompt.md present"
+
+BODY=$(cat "$PROMPT")
+assert_contains "$BODY" "git worktree add" "prompt mentions isolated worktree"
+assert_contains "$BODY" "bash tests/test_" "prompt references bash test suite (fast-fail layer)"
+assert_contains "$BODY" "python3 -m compileall scripts" "prompt references compileall check"
+assert_contains "$BODY" "smoke-test" "prompt references smoke-test (slow verification)"
+assert_contains "$BODY" "gh pr create" "prompt creates a PR via gh"
+assert_contains "$BODY" "Never" "prompt has explicit boundaries (Never ...)"
+assert_contains "$BODY" "merge the PR yourself" "prompt forbids auto-merge (human review required)"
+assert_contains "$BODY" "force-push" "prompt mentions force-push boundary"
+assert_contains "$BODY" "live install" "prompt forbids editing live install (worktree-only)"
+
+# ── 2. Startup block extraction ──────────────────────────────────────────
+
+echo ""
+echo "2. Startup bash block extracted from SKILL.md"
+
+STARTUP=$(extract_startup)
+if [ -z "$STARTUP" ]; then
+  fail "Startup bash block not found in SKILL.md"
+else
+  ok "Startup bash block found"
+fi
+
+# Build a runnable wrapper: pin SCRIPT_DIR to this repo (override the
+# live-install auto-detect) so we read the modes/dev/prompt.md under test.
+STARTUP_WRAPPED=$(printf 'SCRIPT_DIR=%q\n%s\n' "$REPO" "$STARTUP")
+
+# ── 3. Startup emits addendum when profile=dev ───────────────────────────
+
+echo ""
+echo "3. Startup prints the dev addendum when profile=dev"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --profile dev > /dev/null
+OUT=$(HOME="$H" bash -c "$STARTUP_WRAPPED" 2>&1 || true)
+assert_contains "$OUT" "DEV MODE ADDENDUM" "opening marker appears"
+assert_contains "$OUT" "git worktree add" "prompt body is included"
+assert_contains "$OUT" "END DEV MODE ADDENDUM" "closing marker appears"
+
+# ── 4. Default profile stays silent ──────────────────────────────────────
+
+echo ""
+echo "4. Startup stays silent when profile=default"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --profile default > /dev/null
+OUT=$(HOME="$H" bash -c "$STARTUP_WRAPPED" 2>&1 || true)
+if echo "$OUT" | grep -q "DEV MODE ADDENDUM"; then
+  fail "default profile unexpectedly emitted DEV MODE ADDENDUM marker"
+else
+  ok "default profile does not emit the addendum"
+fi
+
+# ── 5. Env override triggers addendum even with default config ───────────
+
+echo ""
+echo "5. AUTONOMOUS_MODE_PROFILE=dev env triggers the addendum"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --profile default > /dev/null
+OUT=$(HOME="$H" AUTONOMOUS_MODE_PROFILE=dev bash -c "$STARTUP_WRAPPED" 2>&1 || true)
+assert_contains "$OUT" "DEV MODE ADDENDUM" "env override triggers addendum"
+
+# ── 6. AUTONOMOUS_SKILL_DIR is exported ──────────────────────────────────
+
+echo ""
+echo "6. AUTONOMOUS_SKILL_DIR exported and points to a real skill repo"
+
+# Note: SKILL.md's Startup re-resolves SCRIPT_DIR from BASH_SOURCE / fallback
+# candidates, so we can't pin it to a sandbox path. Just verify the env var
+# is non-empty, exported, and points to something that looks like a skill repo.
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --profile dev > /dev/null
+PROBE=$(printf '%s\n%s\n' "$STARTUP_WRAPPED" '
+[ -n "$AUTONOMOUS_SKILL_DIR" ] && printf "SET=yes\n" || printf "SET=no\n"
+[ -d "$AUTONOMOUS_SKILL_DIR/scripts" ] && printf "SKILL_REPO=yes\n" || printf "SKILL_REPO=no\n"
+[ -f "$AUTONOMOUS_SKILL_DIR/modes/dev/prompt.md" ] && printf "PROMPT=yes\n" || printf "PROMPT=no\n"
+')
+OUT=$(HOME="$H" bash -c "$PROBE" 2>&1 || true)
+assert_contains "$OUT" "SET=yes" "AUTONOMOUS_SKILL_DIR is set"
+assert_contains "$OUT" "SKILL_REPO=yes" "AUTONOMOUS_SKILL_DIR points to a skill repo (has scripts/)"
+assert_contains "$OUT" "PROMPT=yes" "AUTONOMOUS_SKILL_DIR contains modes/dev/prompt.md"
+
+print_results

--- a/tests/test_user_config.sh
+++ b/tests/test_user_config.sh
@@ -398,4 +398,97 @@ print('ok')
 assert_eq "$(cat /tmp/schema-check.out)" "ok" "every config key is documented in schema"
 rm -f /tmp/schema-check.out
 
+# ── 16. mode.profile ────────────────────────────────────────────────────
+
+echo ""
+echo "16. mode.profile — default value"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --worktrees off --careful off > /dev/null
+PROFILE=$(HOME="$H" python3 "$UC" get mode.profile)
+assert_eq "$PROFILE" "default" "default profile is 'default' when setup omits --profile"
+
+echo ""
+echo "17. mode.profile — setup --profile=dev persists"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --profile dev > /dev/null
+PROFILE=$(HOME="$H" python3 "$UC" get mode.profile)
+assert_eq "$PROFILE" "dev" "setup --profile=dev writes 'dev'"
+
+echo ""
+echo "18. mode.profile — invalid value rejected"
+
+H=$(sandbox_home)
+set +e
+HOME="$H" python3 "$UC" setup --scope global --profile bogus 2>/tmp/profile-err
+RC=$?
+set -e
+assert_eq "$RC" "2" "argparse rejects --profile=bogus with exit code 2"
+assert_contains "$(cat /tmp/profile-err)" "invalid choice" "argparse error mentions invalid choice"
+rm -f /tmp/profile-err
+
+echo ""
+echo "19. mode.profile — 'set' command validates enum"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --worktrees off --careful off > /dev/null
+set +e
+HOME="$H" python3 "$UC" set mode.profile bogus 2>/tmp/profile-err
+RC=$?
+set -e
+if [ "$RC" = "0" ]; then
+  fail "set mode.profile=bogus unexpectedly succeeded"
+else
+  ok "set mode.profile=bogus fails (rc=$RC)"
+fi
+assert_contains "$(cat /tmp/profile-err)" "invalid profile" "error message mentions invalid profile"
+rm -f /tmp/profile-err
+
+echo ""
+echo "20. mode.profile=dev force-enables worktrees in effective config"
+
+H=$(sandbox_home)
+# Explicitly write worktrees=off, then flip profile to dev — the safety
+# rail in load_effective() must override worktrees back to on.
+HOME="$H" python3 "$UC" setup --scope global --worktrees off --careful off --profile dev > /dev/null
+WT=$(HOME="$H" python3 "$UC" get mode.worktrees)
+assert_eq "$WT" "true" "dev profile force-enables worktrees even when config said off"
+
+# Sanity: default profile with worktrees=off stays off
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --worktrees off --careful off --profile default > /dev/null
+WT=$(HOME="$H" python3 "$UC" get mode.worktrees)
+assert_eq "$WT" "false" "default profile does NOT force-enable worktrees"
+
+echo ""
+echo "21. AUTONOMOUS_MODE_PROFILE env override"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --worktrees off --careful off --profile default > /dev/null
+PROFILE=$(HOME="$H" AUTONOMOUS_MODE_PROFILE=dev python3 "$UC" get mode.profile)
+assert_eq "$PROFILE" "dev" "env AUTONOMOUS_MODE_PROFILE=dev overrides config"
+
+# And the env-driven dev profile still force-enables worktrees
+WT=$(HOME="$H" AUTONOMOUS_MODE_PROFILE=dev python3 "$UC" get mode.worktrees)
+assert_eq "$WT" "true" "env-driven dev profile force-enables worktrees via load_effective"
+
+# Invalid env value is ignored (falls through to config's 'default')
+PROFILE=$(HOME="$H" AUTONOMOUS_MODE_PROFILE=bogus python3 "$UC" get mode.profile)
+assert_eq "$PROFILE" "default" "invalid env value ignored, falls back to config"
+
+echo ""
+echo "22. Schema documents mode.profile enum"
+
+python3 -c "
+import json
+s = json.load(open('$SCHEMA_FILE'))
+prof = s['properties']['mode']['properties']['profile']
+assert prof['enum'] == ['default', 'dev'], f'enum mismatch: {prof[\"enum\"]}'
+assert prof['default'] == 'default', f'default mismatch: {prof[\"default\"]}'
+print('ok')
+" > /tmp/profile-schema.out
+assert_eq "$(cat /tmp/profile-schema.out)" "ok" "schema has mode.profile with enum [default,dev]"
+rm -f /tmp/profile-schema.out
+
 print_results


### PR DESCRIPTION
## Summary

Add an opt-in `mode.profile=dev` conductor profile that lets the Conductor
fix bugs in the autonomous-skill tool itself — in addition to the user's
project work.

### How it works
- Config: `mode.profile: "default" | "dev"` (default `"default"`)
- Toggle: `python3 scripts/user-config.py setup --profile dev` or `AUTONOMOUS_MODE_PROFILE=dev`
- When dev: `autonomous/SKILL.md` Startup appends `modes/dev/prompt.md` (wrapped in `=== DEV MODE ADDENDUM ===`) and exports `AUTONOMOUS_SKILL_DIR=$SCRIPT_DIR` so the prompt can locate the skill repo
- When default: no behavioral change

### Dev-mode fix flow (documented in `modes/dev/prompt.md`)
1. Isolated worktree at `$AUTONOMOUS_SKILL_DIR/.worktrees/dev-mode-fix` off fresh `origin/main` — never edits the live install
2. TDD: failing test first, then minimal fix
3. Verification gate (all must pass before PR):
   - `python3 -m compileall scripts`
   - Full `bash tests/test_*.sh` suite
   - `.claude/skills/smoke-test` when coordination-adjacent
4. `gh pr create` for human review — **never auto-merge**, **never force-push main**

### Safety rails
- Dev mode **force-enables** `mode.worktrees=true` in `load_effective()` even if the user config sets it off — a broken fix cannot brick `~/.claude/skills/autonomous-skill`
- Prompt explicitly forbids: force-push to main, auto-merge, editing live install directly, recursive dev-mode sprints
- No change to default profile behavior; existing users unaffected

## Changes
- `scripts/user-config.py`: enum validation, `--profile` flag, `AUTONOMOUS_MODE_PROFILE` env override, force-worktrees rail
- `schemas/autonomous-config.schema.json`: documents `mode.profile`
- `autonomous/SKILL.md`: Startup reads profile and emits addendum
- `modes/dev/prompt.md` (new, 166 lines): full cross-repo fix flow
- `tests/test_dev_mode.sh` (new, 19 tests): prompt content + Startup emission (dev vs default vs env override) + `AUTONOMOUS_SKILL_DIR` export
- `tests/test_user_config.sh` (+26 tests): enum validation, force-worktrees rail, env override, schema coverage
- `CLAUDE.md` + `CHANGELOG.md`: document the feature

## Test plan
- [x] `python3 -m compileall scripts` passes
- [x] `bash tests/test_user_config.sh` — 88/88 pass (was 62/62, +26)
- [x] `bash tests/test_dev_mode.sh` — 19/19 pass (new)
- [x] Full suite unchanged vs main (test_loop.sh has 8 pre-existing failures unrelated to this change, verified against main)
- [x] Manual smoke: `setup --profile=dev` persists; `get mode.profile` returns "dev"; `get mode.worktrees` returns "true" (force-rail); env override `AUTONOMOUS_MODE_PROFILE=dev` works with default config