### PR TITLE
fix(write-summary): land sprint-N-summary.json in the main worktree

### DIFF
--- a/scripts/write-summary.py
+++ b/scripts/write-summary.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
-"""Write sprint-N-summary.json from git state."""
+"""Write sprint-N-summary.json from git state.
+
+IMPORTANT: Sprint masters run inside a linked worktree (e.g.
+``<repo>/.worktrees/sprint-3/``), but the conductor reads the summary
+from the MAIN worktree's ``.autonomous/`` directory. If we naively
+wrote into the sprint worktree's ``.autonomous/``, the conductor's
+monitor would never see the file and would spin until the tmux window
+closed.
+
+To keep both sides of the dispatch aligned, we resolve the main
+worktree via ``git rev-parse --git-common-dir`` (which points to the
+``.git`` of the main worktree from any linked worktree) and write the
+summary there. Falls back to the caller-provided path when git
+resolution fails (edge case: standalone / ad-hoc use outside a repo).
+"""
 from __future__ import annotations
 
 import argparse
@@ -18,6 +32,33 @@ def git_commits(project: Path, limit: int = 5) -> list[str]:
         check=False,
     )
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def main_worktree(project: Path) -> Path:
+    """Resolve the main worktree root for a (possibly linked) project dir.
+
+    ``git rev-parse --path-format=absolute --git-common-dir`` returns the
+    main worktree's ``.git`` directory as an absolute path, whether invoked
+    from the main worktree or from a linked worktree. The main worktree
+    root is that directory's parent.
+
+    Returns ``project`` unchanged when git resolution fails.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return project
+    common_dir = Path(result.stdout.strip() or "")
+    if not common_dir.is_absolute() or not common_dir.exists():
+        return project
+    # common_dir is ``<main_worktree>/.git``; its parent is the main worktree.
+    return common_dir.parent
 
 
 def main(argv: list[str]) -> int:
@@ -42,7 +83,10 @@ def main(argv: list[str]) -> int:
         "iterations_used": args.iterations,
         "direction_complete": args.direction_complete.lower() == "true",
     }
-    target = project / ".autonomous" / f"sprint-{args.sprint_num}-summary.json"
+    # Always land the summary in the main worktree so the conductor can see it.
+    # (The sprint master runs in a linked worktree; see module docstring.)
+    target_root = main_worktree(project)
+    target = target_root / ".autonomous" / f"sprint-{args.sprint_num}-summary.json"
     target.parent.mkdir(exist_ok=True)
     target.write_text(json.dumps(summary, indent=2))
     print(json.dumps(summary, indent=2))


### PR DESCRIPTION
## The bug

When `AUTONOMOUS_SPRINT_WORKTREES=true` (the recommended mode for sprint isolation), the sprint master runs inside a **linked worktree** (`<repo>/.worktrees/sprint-N/`). `SPRINT.md`'s summary step:

```bash
python3 "$SCRIPT_DIR/scripts/write-summary.py" "$(pwd)" "$SPRINT_NUMBER" ...
```

passes `$(pwd)` = the sprint worktree. `write-summary.py` then lands the JSON at:

```
<sprint_worktree>/.autonomous/sprint-N-summary.json
```

But the conductor runs in the **main worktree** and `scripts/monitor-sprint.py` polls:

```
<main_worktree>/.autonomous/sprint-N-summary.json
```

Two different working trees, two different `.autonomous/` directories — file never meets poller.

## Symptoms (seen in the wild)

- Conductor's `monitor-sprint.py` spins until the tmux window closes instead of seeing a clean completion signal. The conductor then can't distinguish "worker done" from "worker crashed."
- Per-sprint summary JSONs pile up inside each sprint worktree's `.autonomous/`. When `merge-sprint.py` merges the sprint branch, those JSONs can get committed and carried back into the session branch, leaving stale JSON dangling in the repo.
- Reproduced in a live 8-sprint run: the user had to add a custom out-of-band `Monitor` tool to detect completion because `monitor-sprint.py` alone wasn't seeing the file.

## The fix

Resolve the **main worktree root** from any linked worktree via `git rev-parse`:

```python
git rev-parse --path-format=absolute --git-common-dir
# returns <main_worktree>/.git — absolute, whether called from main or linked worktree
```

`main_worktree = Path(that).parent`. Write the summary under `main_worktree/.autonomous/`.

Falls back to the caller-provided path when git resolution fails (edge case: standalone / non-repo use).

## Verification

Live-tested in a linked worktree of a real repo:
- `cd /Users/.../i/MAG/.worktrees/eval-migration` (linked)
- `python3 write-summary.py . 99 complete "test"`
- File lands at `/Users/.../i/MAG/.autonomous/sprint-99-summary.json` (main worktree) ✓

No API change, same CLI surface.

## Related

Fixes the root cause of the issue #66 was trying to patch at the prompt level. That PR was closed — this one addresses the actual worktree-path mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)