### PR TITLE
feat(backends): add pluggable Cursor CLI backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to autonomous-skill are documented here.
 
 ## [Unreleased]
 
+### Added
+- Pluggable worker CLI backend — autonomous workers can now be dispatched through either Claude Code (default) or Cursor Agent. Selected via `mode.backend` in user-config (env > project > global, default `claude`). Cursor backend invokes `cursor agent -p --force --trust` with hooks installed at `.cursor/hooks.json` (Cursor has no per-invocation `--settings` flag).
+- `scripts/backends/` — new package containing one module per CLI: `claude.py` (preserves the historic `--dangerously-skip-permissions` invocation + `--settings` careful-hook path) and `cursor.py` (Cursor-specific flags + hook config writer). Each module exposes `cli_name / is_available / install_careful_hook / build_command`.
+- `scripts/dispatch.py` refactored to resolve the backend from config and delegate wrapper construction. Falls back to `claude` with a stderr warning on unknown names so a typo can't silently change which CLI runs.
+- `scripts/hooks/careful-cursor.sh` — Cursor adapter that re-shapes Cursor's preToolUse / beforeShellExecution event into a Claude-shaped Bash event and forwards to the existing `careful.sh` matcher. Returns Cursor's `{permission:"allow|deny",...}` JSON. Probes seven JSON paths so Cursor schema variations don't bypass the guard.
+- `templates/cursor/rules.json` — backend-agnostic worker guidance for Cursor sessions (avoids gstack-only slash commands like `/office-hours`, `/qa`).
+- `schemas/autonomous-config.schema.json` — documents `mode.backend` enum `["claude","cursor"]` with default and env-override note.
+- `scripts/user-config.py` — `mode.backend` config key with `setup --backend` flag, `set` validation against `VALID_BACKENDS`, `AUTONOMOUS_BACKEND` env override, and `get` env-override branch.
+- `tests/test_cursor_backend.sh` (33 tests): backend resolution precedence, env override, invalid-name rejection, dispatch wrapper content for both backends, careful-hook installation under cursor backend (including the "no `--settings` flag" invariant), unknown-backend fallback, careful-cursor.sh adapter event-shape matrix, cursor template rendering.
+- `tests/cursor` — mock Cursor binary mirroring the `tests/claude` env-var contract for deterministic wrapper tests.
+
 
 ## [0.9.0] — 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ All notable changes to autonomous-skill are documented here.
 - `templates/cursor/rules.json` — backend-agnostic worker guidance for Cursor sessions (avoids gstack-only slash commands like `/office-hours`, `/qa`).
 - `schemas/autonomous-config.schema.json` — documents `mode.backend` enum `["claude","cursor"]` with default and env-override note.
 - `scripts/user-config.py` — `mode.backend` config key with `setup --backend` flag, `set` validation against `VALID_BACKENDS`, `AUTONOMOUS_BACKEND` env override, and `get` env-override branch.
-- `tests/test_cursor_backend.sh` (33 tests): backend resolution precedence, env override, invalid-name rejection, dispatch wrapper content for both backends, careful-hook installation under cursor backend (including the "no `--settings` flag" invariant), unknown-backend fallback, careful-cursor.sh adapter event-shape matrix, cursor template rendering.
+- `tests/test_cursor_backend.sh` (42 tests): backend resolution precedence, env override, invalid-name rejection, dispatch wrapper content for both backends, careful-hook installation under cursor backend (including the "no `--settings` flag" invariant), merge-with-existing-user-hooks behavior + idempotency, malformed-hooks recovery + `.bak` backup, unknown-backend fallback, careful-cursor.sh adapter event-shape matrix, cursor template rendering.
 - `tests/cursor` — mock Cursor binary mirroring the `tests/claude` env-var contract for deterministic wrapper tests.
+
+### Changed
+- Cursor backend now **merges** into an existing `.cursor/hooks.json` instead of overwriting it. Autonomous-owned entries are tagged with `_autonomous_managed: true` and refreshed in place; user-authored entries (without that marker) are preserved. Writes are atomic (tmp + rename) so concurrent dispatchers can't tear the file. Malformed pre-existing files are renamed to `hooks.json.bak` before a fresh write.
 
 
 ## [0.9.0] — 2026-04-23

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,11 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/parse-args.py` — Parse ARGS → _MAX_SPRINTS + _DIRECTION
 - `scripts/session-init.py` — Create session branch, init conductor state + backlog
 - `scripts/build-sprint-prompt.py` — Inline SPRINT.md + params → sprint-prompt.md
-- `scripts/dispatch.py` — tmux/headless session dispatch; optionally deploys careful hook when `AUTONOMOUS_WORKER_CAREFUL=1`
+- `scripts/dispatch.py` — tmux/headless session dispatch; resolves the worker CLI backend (`mode.backend`: claude|cursor) and delegates wrapper construction + careful-hook install to the matching `scripts/backends/<name>.py`
+- `scripts/backends/claude.py` — Claude Code backend (default). Builds `exec claude --dangerously-skip-permissions` + per-session `--settings <file>` for the careful hook.
+- `scripts/backends/cursor.py` — Cursor Agent backend. Builds `exec cursor agent -p --force --trust --output-format text` and writes `.cursor/hooks.json` (project-level — Cursor has no per-invocation `--settings` flag) when careful is enabled.
 - `scripts/hooks/careful.sh` — PreToolUse Bash hook; blocks catastrophic patterns (rm -rf /, mkfs, force-push to main, DROP TABLE, fork bombs)
+- `scripts/hooks/careful-cursor.sh` — Cursor adapter for careful.sh: re-shapes Cursor preToolUse / beforeShellExecution events into Claude-shaped Bash events, delegates to careful.sh, returns Cursor's `{permission:"allow|deny",...}` JSON.
 - `scripts/monitor-sprint.py` — Poll for sprint-summary.json
 - `scripts/monitor-worker.py` — Poll comms.json + tmux/process liveness
 - `scripts/evaluate-sprint.py` — Read summary JSON, update conductor state
@@ -43,7 +46,7 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/timeline.py` — Append-only JSONL session event log at `.autonomous/timeline.jsonl` (session-start, sprint-start, sprint-end, phase-transition, session-end)
 - `scripts/explore-scan.py` — Project scanner: scores 8 exploration dimensions via heuristics
 - `scripts/backlog.py` — Cross-session persistent backlog (progressive disclosure, mkdir locking, max 50 items)
-- `scripts/user-config.py` — Global + project config (mode toggles, template, persona scope, experimental flags). Precedence: env > project > global > defaults. Drives first-time AskUserQuestion setup; persists to `~/.claude/autonomous/config.json` or `<project>/.autonomous/config.json`. Written configs reference `schemas/autonomous-config.schema.json` via `$schema` for IDE autocomplete.
+- `scripts/user-config.py` — Global + project config (mode toggles, template, persona scope, backend selector, experimental flags). Precedence: env > project > global > defaults. Drives first-time AskUserQuestion setup; persists to `~/.claude/autonomous/config.json` or `<project>/.autonomous/config.json`. Written configs reference `schemas/autonomous-config.schema.json` via `$schema` for IDE autocomplete. Knows `mode.backend` (claude|cursor) with `AUTONOMOUS_BACKEND` env override and `setup --backend` flag.
 - `schemas/autonomous-config.schema.json` — JSON Schema (draft-07) documenting the full config shape with per-field descriptions. IDEs use it for autocomplete + validation.
 - `scripts/checkpoint.py` — Human-readable markdown snapshots of session state at `.autonomous/checkpoints/<ts>-<slug>.md` (save/list/latest/show)
 - `scripts/persona.py` — OWNER.md auto-generation from git history + project docs
@@ -62,6 +65,7 @@ Conductor (SKILL.md, user's CC session)
 - `.claude/skills/diff-sessions/SKILL.md` — Compare two worker sessions side-by-side
 - `templates/gstack/rules.json` — gstack toolchain worker slash-command rules (allows + blocks)
 - `templates/default/rules.json` — Generic worker guidance with no toolchain assumptions
+- `templates/cursor/rules.json` — Worker guidance for sessions dispatched via Cursor (avoids gstack-only slash commands; uses backend-agnostic phrasing). Compose with `mode.templates=cursor` when running with `mode.backend=cursor`.
 - `scripts/build-sprint-prompt.py` — Composes the active `mode.templates` rules into SPRINT.md's allow/block markers
 - `explore-ralph-loop/SKILL.md` — Explore Ralph Loop: detects toolchain, captures execute-verify-fix patterns as reusable skills
 - `scripts/register-ralph-loops.sh` — Dynamic scanner: symlinks ralph-loop-skills/ to ~/.claude/skills/
@@ -164,7 +168,7 @@ To add a new template: create `templates/<name>/rules.json` with `allows` and
 
 ## Testing
 
-785 tests across 15 suites, all pure bash:
+818 tests across 16 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -182,6 +186,7 @@ bash tests/test_worktree.sh     # 65 tests: per-sprint worktree CRUD, symlink es
 bash tests/test_user_config.sh  # 88 tests: config precedence, legacy migration, malformed config, experimental flags + warnings, init command, $schema reference, schema file integrity, mode.profile (default/dev enum + validation + force-worktrees rail + env override)
 bash tests/test_parallel_sprint.sh # 27 tests: V2 parallel orchestrator — gating, validation, E2E wave dispatch + serial merge + worktree teardown, max-parallel sources
 bash tests/test_dev_mode.sh     # 19 tests: modes/dev/prompt.md content + SKILL.md Startup addendum emission (dev vs default profile, env override, AUTONOMOUS_SKILL_DIR export)
+bash tests/test_cursor_backend.sh # 33 tests: backend resolution precedence, AUTONOMOUS_BACKEND env, invalid-name rejection, dispatch wrapper for both backends, cursor careful-hook installation (.cursor/hooks.json + no --settings invariant), unknown-backend fallback, careful-cursor.sh adapter event-shape matrix, cursor template render
 python3 -m compileall scripts   # quick syntax check
 ```
 
@@ -190,6 +195,8 @@ Test harness uses `tests/claude` (mock CC binary) controlled by env vars:
 - `MOCK_CLAUDE_COMMIT=1` — make a git commit during the mock run
 - `MOCK_CLAUDE_DELAY` — sleep N seconds (for timeout tests)
 - `MOCK_CLAUDE_EXIT` — exit code to return
+
+`tests/cursor` mirrors that contract for the Cursor backend (`MOCK_CURSOR_DELAY`, `MOCK_CURSOR_EXIT`, `MOCK_CURSOR_OUTPUT`).
 
 ## Development workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ To add a new template: create `templates/<name>/rules.json` with `allows` and
 
 ## Testing
 
-818 tests across 16 suites, all pure bash:
+827 tests across 16 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -186,7 +186,7 @@ bash tests/test_worktree.sh     # 65 tests: per-sprint worktree CRUD, symlink es
 bash tests/test_user_config.sh  # 88 tests: config precedence, legacy migration, malformed config, experimental flags + warnings, init command, $schema reference, schema file integrity, mode.profile (default/dev enum + validation + force-worktrees rail + env override)
 bash tests/test_parallel_sprint.sh # 27 tests: V2 parallel orchestrator — gating, validation, E2E wave dispatch + serial merge + worktree teardown, max-parallel sources
 bash tests/test_dev_mode.sh     # 19 tests: modes/dev/prompt.md content + SKILL.md Startup addendum emission (dev vs default profile, env override, AUTONOMOUS_SKILL_DIR export)
-bash tests/test_cursor_backend.sh # 33 tests: backend resolution precedence, AUTONOMOUS_BACKEND env, invalid-name rejection, dispatch wrapper for both backends, cursor careful-hook installation (.cursor/hooks.json + no --settings invariant), unknown-backend fallback, careful-cursor.sh adapter event-shape matrix, cursor template render
+bash tests/test_cursor_backend.sh # 42 tests: backend resolution precedence, AUTONOMOUS_BACKEND env, invalid-name rejection, dispatch wrapper for both backends, cursor careful-hook installation (.cursor/hooks.json + no --settings invariant) + merge-with-existing-user-hooks + idempotency + malformed-recovery, unknown-backend fallback, careful-cursor.sh adapter event-shape matrix, cursor template render
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/schemas/autonomous-config.schema.json
+++ b/schemas/autonomous-config.schema.json
@@ -41,6 +41,12 @@
           "enum": ["default", "dev"],
           "default": "default",
           "description": "Conductor profile. 'default' runs the normal project-directed flow. 'dev' additionally injects modes/dev/prompt.md — giving the conductor permission to fix bugs in the autonomous-skill tool itself via an isolated worktree, bash+smoke-test verification gate, and a human-review PR. Dev profile force-enables mode.worktrees (safety rail: a broken fix cannot corrupt the live install). Env override: AUTONOMOUS_MODE_PROFILE."
+        },
+        "backend": {
+          "type": "string",
+          "enum": ["claude", "cursor"],
+          "default": "claude",
+          "description": "Worker CLI backend. 'claude' invokes `claude --dangerously-skip-permissions` (historic default). 'cursor' invokes `cursor agent -p --force --trust` and writes hooks to .cursor/hooks.json instead of using --settings (Cursor has no per-invocation settings flag). Env override: AUTONOMOUS_BACKEND."
         }
       }
     },

--- a/scripts/backends/__init__.py
+++ b/scripts/backends/__init__.py
@@ -1,0 +1,23 @@
+"""Pluggable CLI backends for autonomous workers.
+
+Each backend module exposes the same surface so dispatch.py can swap
+underlying CLIs without conditionals scattered through the codebase:
+
+    cli_name() -> str
+        Display name used in log lines / errors.
+
+    is_available() -> bool
+        Whether the CLI binary is on PATH.
+
+    install_careful_hook(project_dir, window) -> str
+        Side-effect: writes per-session hook config so the worker's
+        destructive-command guard fires. Returns extra CLI args (e.g.
+        ' --settings ...') to splice into the invocation, or "" when the
+        backend reads its hook config from a file the script just wrote.
+
+    build_command(extra_args) -> str
+        Returns the shell line that runs the CLI with $PROMPT pre-set.
+
+Selection is driven by `mode.backend` in user-config (env > project > global,
+default "claude"). See dispatch.resolve_backend.
+"""

--- a/scripts/backends/claude.py
+++ b/scripts/backends/claude.py
@@ -1,0 +1,54 @@
+"""Claude Code CLI backend (default).
+
+Mirrors the historic dispatch.py behavior so existing installs keep working
+with no config changes.
+"""
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+from pathlib import Path
+
+NAME = "claude"
+
+
+def cli_name() -> str:
+    return "claude"
+
+
+def is_available() -> bool:
+    return shutil.which("claude") is not None
+
+
+def install_careful_hook(project_dir: Path, window: str) -> str:
+    """Write a per-session settings JSON registering scripts/hooks/careful.sh
+    as a PreToolUse Bash hook. Returns the ' --settings <path>' fragment to
+    append to the CLI invocation. Empty string if the hook script is missing
+    (treated as a no-op rather than a hard failure)."""
+    hook_script = Path(__file__).resolve().parent.parent / "hooks" / "careful.sh"
+    if not hook_script.exists():
+        return ""
+    settings_path = project_dir / ".autonomous" / f"settings-{window}.json"
+    settings_path.parent.mkdir(exist_ok=True)
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": f"bash {hook_script}",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    settings_path.write_text(json.dumps(settings, indent=2))
+    return f" --settings {shlex.quote(str(settings_path))}"
+
+
+def build_command(extra_args: str) -> str:
+    return f"exec claude --dangerously-skip-permissions{extra_args} \"$PROMPT\""

--- a/scripts/backends/cursor.py
+++ b/scripts/backends/cursor.py
@@ -15,14 +15,22 @@ Hook model differs from Claude:
   worker dispatched against this project. Concurrent sessions in the SAME
   project would clash; combine with mode.worktrees=true to isolate each
   sprint in `.worktrees/sprint-N/`, where each gets its own .cursor dir.
+
+Existing hooks.json is merged, not clobbered. We tag our entries with
+`_autonomous_managed: true` and only add (or refresh) those entries; any
+user-authored hook entries (no marker) survive untouched. Writes are
+atomic (tmp + rename) so concurrent dispatchers can't tear the file.
 """
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import tempfile
 from pathlib import Path
 
 NAME = "cursor"
+MANAGED_KEY = "_autonomous_managed"
 
 
 def cli_name() -> str:
@@ -33,28 +41,72 @@ def is_available() -> bool:
     return shutil.which("cursor") is not None
 
 
+def _merge_hook_entry(existing: list, adapter: Path) -> list:
+    """Drop any prior autonomous-managed entry, then append a fresh one.
+    Preserves user-authored entries (those without MANAGED_KEY).
+    """
+    out = []
+    for entry in existing if isinstance(existing, list) else []:
+        if isinstance(entry, dict) and entry.get(MANAGED_KEY) is True:
+            continue
+        out.append(entry)
+    out.append({MANAGED_KEY: True, "command": f"bash {adapter}"})
+    return out
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(payload, f, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 def install_careful_hook(project_dir: Path, window: str) -> str:
-    """Write `.cursor/hooks.json` registering careful-cursor.sh as the
-    preToolUse + beforeShellExecution adapter. Returns "" because Cursor
-    discovers hooks from the file alone — no extra CLI flag required."""
+    """Merge our preToolUse + beforeShellExecution entries into
+    `.cursor/hooks.json`. Returns "" because Cursor discovers hooks from
+    the file alone — no extra CLI flag required.
+
+    User-authored entries are preserved; only entries marked with
+    MANAGED_KEY are refreshed. Writes are atomic (tmp+rename).
+    """
     adapter = Path(__file__).resolve().parent.parent / "hooks" / "careful-cursor.sh"
     if not adapter.exists():
         return ""
     cursor_dir = project_dir / ".cursor"
     cursor_dir.mkdir(exist_ok=True)
     hooks_path = cursor_dir / "hooks.json"
-    config = {
-        "version": 1,
-        "hooks": {
-            "beforeShellExecution": [
-                {"command": f"bash {adapter}"}
-            ],
-            "preToolUse": [
-                {"command": f"bash {adapter}"}
-            ],
-        },
-    }
-    hooks_path.write_text(json.dumps(config, indent=2))
+
+    config: dict = {"version": 1, "hooks": {}}
+    if hooks_path.exists():
+        try:
+            loaded = json.loads(hooks_path.read_text())
+            if isinstance(loaded, dict):
+                config = loaded
+                if not isinstance(config.get("hooks"), dict):
+                    config["hooks"] = {}
+                config.setdefault("version", 1)
+        except (json.JSONDecodeError, OSError):
+            # Malformed user file → start fresh, but back it up so the
+            # user can recover.
+            try:
+                hooks_path.rename(hooks_path.with_suffix(".json.bak"))
+            except OSError:
+                pass
+            config = {"version": 1, "hooks": {}}
+
+    for event in ("beforeShellExecution", "preToolUse"):
+        config["hooks"][event] = _merge_hook_entry(
+            config["hooks"].get(event, []), adapter
+        )
+
+    _atomic_write_json(hooks_path, config)
     return ""
 
 

--- a/scripts/backends/cursor.py
+++ b/scripts/backends/cursor.py
@@ -1,0 +1,69 @@
+"""Cursor Agent CLI backend.
+
+Cursor's CLI (`cursor agent -p`) supports headless scripting with --force
+(equivalent to --dangerously-skip-permissions) and --trust (required for
+non-interactive sessions). It reads MCP from mcp.json and rules from
+.cursor/rules + CLAUDE.md/AGENTS.md at the project root automatically.
+
+Hook model differs from Claude:
+- No per-invocation `--settings` flag exists.
+- Hooks are read from `.cursor/hooks.json` (project) or `~/.cursor/hooks.json`
+  (user). We write the project-level file so the careful-cursor.sh adapter
+  fires for this session.
+- Because the file is project-level it persists across runs in the same
+  worktree. That's fine — the same careful guard should apply to every
+  worker dispatched against this project. Concurrent sessions in the SAME
+  project would clash; combine with mode.worktrees=true to isolate each
+  sprint in `.worktrees/sprint-N/`, where each gets its own .cursor dir.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+NAME = "cursor"
+
+
+def cli_name() -> str:
+    return "cursor"
+
+
+def is_available() -> bool:
+    return shutil.which("cursor") is not None
+
+
+def install_careful_hook(project_dir: Path, window: str) -> str:
+    """Write `.cursor/hooks.json` registering careful-cursor.sh as the
+    preToolUse + beforeShellExecution adapter. Returns "" because Cursor
+    discovers hooks from the file alone — no extra CLI flag required."""
+    adapter = Path(__file__).resolve().parent.parent / "hooks" / "careful-cursor.sh"
+    if not adapter.exists():
+        return ""
+    cursor_dir = project_dir / ".cursor"
+    cursor_dir.mkdir(exist_ok=True)
+    hooks_path = cursor_dir / "hooks.json"
+    config = {
+        "version": 1,
+        "hooks": {
+            "beforeShellExecution": [
+                {"command": f"bash {adapter}"}
+            ],
+            "preToolUse": [
+                {"command": f"bash {adapter}"}
+            ],
+        },
+    }
+    hooks_path.write_text(json.dumps(config, indent=2))
+    return ""
+
+
+def build_command(extra_args: str) -> str:
+    # --force / --yolo: bypass per-command approval (mirrors --dangerously-skip-permissions)
+    # --trust:          required for headless mode (skip workspace-trust prompt)
+    # --output-format text: matches the simple log we capture today; future
+    #                  master-watch parser can opt into stream-json.
+    return (
+        f"exec cursor agent -p --force --trust --output-format text"
+        f"{extra_args} \"$PROMPT\""
+    )

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Launch claude sessions via tmux or headless background."""
+"""Launch worker sessions via tmux or headless background.
+
+Backend (Claude vs Cursor vs ...) is resolved from `mode.backend` in
+user-config (env > project > global, default "claude"). Each backend
+module under `scripts/backends/` knows how to assemble its CLI invocation
+and install its own careful-hook config.
+"""
 from __future__ import annotations
 
 import argparse
-import json
+import importlib
 import os
 import re
 import shlex
@@ -19,6 +25,8 @@ from pathlib import Path
 # alphanumerics, dot, dash, underscore; capped at 64 chars.
 _WINDOW_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 
+KNOWN_BACKENDS = {"claude", "cursor"}
+
 
 def tmux_available() -> bool:
     return (
@@ -33,69 +41,70 @@ def tmux_available() -> bool:
     )
 
 
-def _careful_enabled(project_dir: Path) -> bool:
-    """Honor env var first (debug override), fall through to user-config."""
-    env_raw = os.environ.get("AUTONOMOUS_WORKER_CAREFUL", "")
-    if env_raw:
-        return env_raw.lower() in {"1", "true", "yes", "on"}
+def _user_config_get(project_dir: Path, key: str) -> str:
+    """Thin shell over user-config.py `get`. Returns "" on any failure so
+    callers can fall back to defaults without try/except plumbing."""
     config_script = Path(__file__).resolve().parent / "user-config.py"
     if not config_script.exists():
-        return False
+        return ""
     try:
         result = subprocess.run(
-            [sys.executable, str(config_script), "get",
-             "mode.careful_hook", str(project_dir)],
+            [sys.executable, str(config_script), "get", key, str(project_dir)],
             capture_output=True,
             text=True,
             check=False,
             timeout=5,
         )
     except (subprocess.TimeoutExpired, OSError):
-        return False
-    return result.stdout.strip() == "true"
+        return ""
+    return result.stdout.strip()
 
 
-def careful_settings_path(project_dir: Path, window: str) -> Path | None:
-    """Generate a per-session settings JSON registering the careful hook.
-    Returns the path when enabled (via user-config or env var), None otherwise."""
-    if not _careful_enabled(project_dir):
-        return None
-    hook_script = Path(__file__).resolve().parent / "hooks" / "careful.sh"
-    if not hook_script.exists():
-        return None
-    settings_path = project_dir / ".autonomous" / f"settings-{window}.json"
-    settings_path.parent.mkdir(exist_ok=True)
-    settings = {
-        "hooks": {
-            "PreToolUse": [
-                {
-                    "matcher": "Bash",
-                    "hooks": [
-                        {
-                            "type": "command",
-                            "command": f"bash {hook_script}",
-                        }
-                    ],
-                }
-            ]
-        }
-    }
-    settings_path.write_text(json.dumps(settings, indent=2))
-    return settings_path
+def _careful_enabled(project_dir: Path) -> bool:
+    """Honor env var first (debug override), fall through to user-config."""
+    env_raw = os.environ.get("AUTONOMOUS_WORKER_CAREFUL", "")
+    if env_raw:
+        return env_raw.lower() in {"1", "true", "yes", "on"}
+    return _user_config_get(project_dir, "mode.careful_hook") == "true"
 
 
-def create_wrapper(project_dir: Path, prompt_file: Path, window: str) -> Path:
+def resolve_backend(project_dir: Path):
+    """Pick the backend module (claude|cursor) for this dispatch.
+
+    Precedence: AUTONOMOUS_BACKEND env > project/global config > 'claude'.
+    Unknown names fall back to 'claude' with a stderr warning so a typo
+    doesn't silently change behavior."""
+    env_raw = os.environ.get("AUTONOMOUS_BACKEND", "").strip().lower()
+    name = env_raw or _user_config_get(project_dir, "mode.backend") or "claude"
+    if name not in KNOWN_BACKENDS:
+        print(
+            f"WARNING: unknown backend '{name}'; falling back to 'claude'. "
+            f"Valid backends: {sorted(KNOWN_BACKENDS)}",
+            file=sys.stderr,
+        )
+        name = "claude"
+    # Make `from backends import ...` work when dispatch.py is invoked
+    # directly via `python3 scripts/dispatch.py ...` without a package install.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    return importlib.import_module(f"backends.{name}")
+
+
+def create_wrapper(
+    project_dir: Path, prompt_file: Path, window: str, backend
+) -> Path:
     wrapper = project_dir / ".autonomous" / f"run-{window}.sh"
     wrapper.parent.mkdir(exist_ok=True)
-    settings_file = careful_settings_path(project_dir, window)
+    extra_args = ""
+    if _careful_enabled(project_dir):
+        extra_args = backend.install_careful_hook(project_dir, window)
+    cli_line = backend.build_command(extra_args)
     # shlex.quote() produces properly-escaped single-quoted literals so the
     # interpolated path can never break out of its argument context.
-    settings_arg = f" --settings {shlex.quote(str(settings_file))}" if settings_file else ""
     content = (
         "#!/bin/bash\n"
         f"cd {shlex.quote(str(project_dir))}\n"
         f"PROMPT=$(cat {shlex.quote(str(prompt_file))})\n"
-        f"exec claude --dangerously-skip-permissions{settings_arg} \"$PROMPT\"\n"
+        f"{cli_line}\n"
     )
     wrapper.write_text(content)
     wrapper.chmod(0o755)
@@ -103,7 +112,7 @@ def create_wrapper(project_dir: Path, prompt_file: Path, window: str) -> Path:
 
 
 def main(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(description="Dispatch claude session")
+    parser = argparse.ArgumentParser(description="Dispatch worker session")
     parser.add_argument("project_dir")
     parser.add_argument("prompt_file")
     parser.add_argument("window_name")
@@ -123,7 +132,15 @@ def main(argv: list[str]) -> int:
         print(f"ERROR: Prompt file not found: {prompt}", file=sys.stderr)
         return 1
 
-    wrapper = create_wrapper(project, prompt, args.window_name)
+    backend = resolve_backend(project)
+    if not backend.is_available():
+        print(
+            f"WARNING: backend '{backend.cli_name()}' binary not found on PATH. "
+            "Wrapper will still be written but the dispatched session will fail.",
+            file=sys.stderr,
+        )
+
+    wrapper = create_wrapper(project, prompt, args.window_name, backend)
 
     env_mode = os.environ.get("DISPATCH_MODE", "").lower()
 

--- a/scripts/hooks/careful-cursor.sh
+++ b/scripts/hooks/careful-cursor.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# careful-cursor.sh — Cursor adapter for autonomous workers.
+#
+# Cursor's hook protocol differs from Claude's:
+#   - Cursor reads .cursor/hooks.json (project) or ~/.cursor/hooks.json (user).
+#   - Hook scripts receive a JSON event on stdin and return a permission JSON
+#     on stdout: {"permission":"allow|deny|ask","user_message":"...",...}.
+#   - Exit code 2 also blocks (matches Claude's behavior).
+#
+# This adapter:
+#   1. Pulls the shell command out of the Cursor event (preToolUse or
+#      beforeShellExecution — schema varies, so we probe several JSON paths).
+#   2. Forwards a Claude-shaped Bash event to scripts/hooks/careful.sh so the
+#      catastrophic-pattern matcher stays in one place.
+#   3. Translates the bash hook's exit code into Cursor's permission JSON.
+#
+# Deployed by scripts/backends/cursor.py when AUTONOMOUS_WORKER_CAREFUL=1
+# (or mode.careful_hook=true in user-config) is set.
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract shell command from Cursor's event JSON. Different events nest the
+# command under different keys; try the most likely paths in order. Use
+# `python3 -c <script>` (NOT a heredoc) so the JSON we just read still reaches
+# Python's stdin via the pipe.
+CMD=$(printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    print("")
+    sys.exit(0)
+if not isinstance(d, dict):
+    print("")
+    sys.exit(0)
+candidates = [
+    ("command",),
+    ("shell_command",),
+    ("tool_input", "command"),
+    ("input", "command"),
+    ("params", "command"),
+    ("arguments", "command"),
+    ("tool", "input", "command"),
+]
+for path in candidates:
+    cur = d
+    ok = True
+    for key in path:
+        if isinstance(cur, dict) and key in cur:
+            cur = cur[key]
+        else:
+            ok = False
+            break
+    if ok and isinstance(cur, str) and cur:
+        print(cur)
+        sys.exit(0)
+print("")
+' 2>/dev/null || true)
+
+# No shell command in the event → not our problem; allow.
+if [ -z "$CMD" ]; then
+  echo '{"permission":"allow"}'
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_HOOK="$SCRIPT_DIR/careful.sh"
+
+# Re-pack as a Claude-shaped tool_input event and delegate.
+CLAUDE_INPUT=$(python3 -c "import json,sys; print(json.dumps({'tool_name':'Bash','tool_input':{'command':sys.argv[1]}}))" "$CMD")
+
+STDERR_FILE=$(mktemp -t careful-cursor.XXXXXX)
+trap 'rm -f "$STDERR_FILE"' EXIT
+
+if printf '%s' "$CLAUDE_INPUT" | bash "$CLAUDE_HOOK" >/dev/null 2>"$STDERR_FILE"; then
+  echo '{"permission":"allow"}'
+  exit 0
+fi
+
+REASON=$(cat "$STDERR_FILE" 2>/dev/null || echo "blocked by autonomous-skill careful hook")
+python3 -c "
+import json, sys
+reason = sys.argv[1] if len(sys.argv) > 1 else 'blocked'
+print(json.dumps({
+    'permission': 'deny',
+    'user_message': reason,
+    'agent_message': reason,
+}))
+" "$REASON"
+exit 0

--- a/scripts/user-config.py
+++ b/scripts/user-config.py
@@ -21,7 +21,7 @@ Commands:
                               to run the first-time AskUserQuestion flow.
   get <key> [project]       — print the effective value (with env overrides).
                               Example keys: mode.worktrees, mode.careful_hook,
-                              mode.templates, persona.scope.
+                              mode.templates, mode.backend, persona.scope.
                               `mode.template` (singular) still works as a
                               read-only alias returning the first entry of
                               `mode.templates`.
@@ -42,6 +42,7 @@ Commands:
 Values:
   mode.worktrees, mode.careful_hook  → bool (true|false)
   mode.templates                     → list[str] (e.g., ["gstack"], ["default","custom"])
+  mode.backend                       → string (claude|cursor)
   persona.scope                      → string (global|project)
 """
 from __future__ import annotations
@@ -68,6 +69,7 @@ ENV_OVERRIDES: dict[str, str] = {
     "mode.worktrees": "AUTONOMOUS_SPRINT_WORKTREES",
     "mode.careful_hook": "AUTONOMOUS_WORKER_CAREFUL",
     "mode.profile": "AUTONOMOUS_MODE_PROFILE",
+    "mode.backend": "AUTONOMOUS_BACKEND",
 }
 
 BOOL_KEYS = {
@@ -76,13 +78,17 @@ BOOL_KEYS = {
     "experimental.vira_worktree",
     "experimental.parallel_sprints",
 }
-STRING_KEYS = {"persona.scope", "mode.profile"}
+STRING_KEYS = {"persona.scope", "mode.profile", "mode.backend"}
 LIST_KEYS = {"mode.templates"}
 VALID_PERSONA_SCOPES = {"global", "project"}
 # Profile is a one-line switch that tells SKILL.md whether to inject the
 # dev-mode addendum. Extend cautiously — each new profile should have a
 # matching modes/<name>/prompt.md or it's a no-op.
 VALID_PROFILES = {"default", "dev"}
+# Backends correspond to scripts/backends/<name>.py modules. Extend by
+# adding a module that exposes cli_name/is_available/install_careful_hook/
+# build_command, then list the name here.
+VALID_BACKENDS = {"claude", "cursor"}
 
 # Experimental keys surface a stderr warning on every `check` so the user
 # never forgets they're running unstable code. Extend this set when adding
@@ -102,6 +108,9 @@ DEFAULTS: dict[str, Any] = {
         # Dev mode force-enables worktrees (see load_effective) so a broken
         # fix can't brick the live install.
         "profile": "default",
+        # Worker CLI to dispatch. "claude" is the historic default;
+        # "cursor" routes through `cursor agent -p` (see scripts/backends/).
+        "backend": "claude",
     },
     "persona": {
         "scope": "global",
@@ -333,6 +342,10 @@ def _coerce_value(key: str, raw: str) -> Any:
         if raw not in VALID_PROFILES:
             die(f"invalid profile: {raw} (use {'|'.join(sorted(VALID_PROFILES))})")
         return raw
+    if key == "mode.backend":
+        if raw not in VALID_BACKENDS:
+            die(f"invalid backend: {raw} (use {'|'.join(sorted(VALID_BACKENDS))})")
+        return raw
     if key in STRING_KEYS:
         return raw
     die(f"unknown key: {key}")
@@ -363,6 +376,11 @@ def cmd_get(args: argparse.Namespace) -> None:
         elif key == "mode.profile":
             if raw in VALID_PROFILES:
                 print(raw)
+                return
+            # Invalid env value — ignore, fall through to config
+        elif key == "mode.backend":
+            if raw.lower() in VALID_BACKENDS:
+                print(raw.lower())
                 return
             # Invalid env value — ignore, fall through to config
         elif key in STRING_KEYS:
@@ -454,6 +472,8 @@ def cmd_setup(args: argparse.Namespace) -> None:
         die(f"invalid --careful: {args.careful}")
     if args.profile and args.profile not in VALID_PROFILES:
         die(f"invalid --profile: {args.profile} (use {'|'.join(sorted(VALID_PROFILES))})")
+    if getattr(args, "backend", None) and args.backend not in VALID_BACKENDS:
+        die(f"invalid --backend: {args.backend} (use {'|'.join(sorted(VALID_BACKENDS))})")
 
     def mutate(cfg: dict[str, Any]) -> None:
         if worktrees is not None:
@@ -468,6 +488,8 @@ def cmd_setup(args: argparse.Namespace) -> None:
             _set_nested(cfg, "mode.templates", single)
         if args.profile:
             _set_nested(cfg, "mode.profile", args.profile)
+        if getattr(args, "backend", None):
+            _set_nested(cfg, "mode.backend", args.backend)
         if args.persona_scope:
             if args.persona_scope not in VALID_PERSONA_SCOPES:
                 die(f"invalid --persona-scope: {args.persona_scope}")
@@ -629,6 +651,13 @@ def build_parser() -> argparse.ArgumentParser:
         choices=sorted(VALID_PROFILES),
         help="conductor profile: 'default' or 'dev' "
         "(dev unlocks self-improvement flow + force-enables worktrees)",
+    )
+    p_setup.add_argument(
+        "--backend",
+        default=None,
+        choices=sorted(VALID_BACKENDS),
+        help="worker CLI backend: 'claude' (default) or 'cursor' "
+        "(routes dispatch through `cursor agent -p`)",
     )
     p_setup.set_defaults(func=cmd_setup)
 

--- a/templates/cursor/rules.json
+++ b/templates/cursor/rules.json
@@ -1,0 +1,14 @@
+{
+  "name": "cursor",
+  "description": "Worker guidance for sessions dispatched through the Cursor agent CLI. Avoids gstack/Claude-only slash commands (which Cursor sessions don't have) and falls back to direct, backend-agnostic phrasing.",
+  "allows": [
+    "New idea? -> \"Sketch the smallest version that proves the idea, then expand.\"",
+    "Need implementation? -> \"Build this end-to-end. Reference the design doc if one exists.\"",
+    "Feels fragile? -> \"Audit this module for fragility (error paths, race conditions, missing tests) and propose fixes.\"",
+    "Bug? -> \"Reproduce first, then root-cause before patching.\""
+  ],
+  "blocks": [
+    "Never invoke shell commands that ship code (git push to main, npm publish, vercel --prod, gh release create, gh pr merge).",
+    "Never run destructive shell commands (rm -rf /, mkfs, dd to raw devices, DROP TABLE)."
+  ]
+}

--- a/tests/cursor
+++ b/tests/cursor
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Mock Cursor CLI binary for testing.
+# Drop tests/ into PATH before real cursor to intercept calls.
+#
+# Environment controls (parallel to tests/claude):
+#   MOCK_CURSOR_DELAY   Sleep N seconds before responding (timeout tests)
+#   MOCK_CURSOR_EXIT    Exit code to return (default: 0) — exits before output
+#   MOCK_CURSOR_OUTPUT  Text to print for `cursor agent -p`
+#
+# Cursor's CLI takes a subcommand: `cursor agent <args>`. We accept any
+# leading positional + flags and just emit a deterministic line so wrapper
+# tests can confirm the binary was reached.
+
+[ -n "${MOCK_CURSOR_DELAY:-}" ] && sleep "$MOCK_CURSOR_DELAY"
+
+if [ "${MOCK_CURSOR_EXIT:-0}" != "0" ]; then
+  exit "$MOCK_CURSOR_EXIT"
+fi
+
+# Support `cursor --version` / `cursor agent --version` minimally so any
+# `is_available`-style probe doesn't error.
+for arg in "$@"; do
+  case "$arg" in
+    --version|-v)
+      echo "cursor 0.0.0-mock"
+      exit 0
+      ;;
+  esac
+done
+
+# Default response — short, machine-greppable.
+echo "${MOCK_CURSOR_OUTPUT:-mock cursor agent OK}"

--- a/tests/test_cursor_backend.sh
+++ b/tests/test_cursor_backend.sh
@@ -138,7 +138,66 @@ assert_file_contains "$HOOKS" "beforeShellExecution" "hooks.json has beforeShell
 assert_file_contains "$HOOKS" "careful-cursor.sh" "hooks.json points at careful-cursor.sh adapter"
 # Cursor has no --settings flag — wrapper must not invent one
 assert_file_not_contains "$WRAPPER" "\-\-settings" "wrapper does not pass --settings to cursor"
+assert_file_contains "$HOOKS" "_autonomous_managed" "managed marker present on autonomous-owned entries"
 pkill -f "run-carefulwin.sh" 2>/dev/null || true
+
+# ── 7b. Existing user hooks.json survives merge ──────────────────────────
+
+echo ""
+echo "7b. cursor backend preserves user hooks"
+
+H=$(sandbox_home)
+T=$(make_project)
+mkdir -p "$T/.cursor"
+cat > "$T/.cursor/hooks.json" <<'JSON'
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {"command": "echo user-lint-hook"}
+    ],
+    "afterFileEdit": [
+      {"command": "echo user-format-hook"}
+    ]
+  }
+}
+JSON
+HOME="$H" python3 "$UC" set mode.backend cursor --scope global > /dev/null
+HOME="$H" python3 "$UC" set mode.careful_hook true --scope global > /dev/null
+echo "test prompt" > "$T/prompt.txt"
+HOME="$H" DISPATCH_MODE=headless python3 "$DISPATCH" "$T" "$T/prompt.txt" mergewin > /dev/null 2>&1 || true
+HOOKS="$T/.cursor/hooks.json"
+assert_file_exists "$HOOKS" "merged hooks.json exists"
+assert_file_contains "$HOOKS" "user-lint-hook" "user preToolUse entry preserved"
+assert_file_contains "$HOOKS" "user-format-hook" "user afterFileEdit entry preserved"
+assert_file_contains "$HOOKS" "_autonomous_managed" "autonomous managed entry added"
+assert_file_contains "$HOOKS" "careful-cursor.sh" "autonomous adapter wired into preToolUse"
+# Re-running must not duplicate our managed entry
+HOME="$H" DISPATCH_MODE=headless python3 "$DISPATCH" "$T" "$T/prompt.txt" mergewin2 > /dev/null 2>&1 || true
+COUNT=$(grep -c "_autonomous_managed" "$HOOKS" || true)
+if [ "$COUNT" -eq 2 ]; then
+  ok "managed entries idempotent (one per event, two events)"
+else
+  fail "expected 2 managed markers (preToolUse + beforeShellExecution); got $COUNT"
+fi
+pkill -f "run-mergewin" 2>/dev/null || true
+
+# ── 7c. Malformed hooks.json gets backed up, not propagated ──────────────
+
+echo ""
+echo "7c. cursor backend recovers from malformed hooks.json"
+
+H=$(sandbox_home)
+T=$(make_project)
+mkdir -p "$T/.cursor"
+echo '{not valid json' > "$T/.cursor/hooks.json"
+HOME="$H" python3 "$UC" set mode.backend cursor --scope global > /dev/null
+HOME="$H" python3 "$UC" set mode.careful_hook true --scope global > /dev/null
+echo "test prompt" > "$T/prompt.txt"
+HOME="$H" DISPATCH_MODE=headless python3 "$DISPATCH" "$T" "$T/prompt.txt" recoverwin > /dev/null 2>&1 || true
+assert_file_exists "$T/.cursor/hooks.json.bak" "malformed hooks.json backed up"
+assert_file_contains "$T/.cursor/hooks.json" "_autonomous_managed" "fresh hooks.json written after recovery"
+pkill -f "run-recoverwin.sh" 2>/dev/null || true
 
 # ── 8. Unknown backend falls back to claude with warning ────────────────
 

--- a/tests/test_cursor_backend.sh
+++ b/tests/test_cursor_backend.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# test_cursor_backend.sh — Cursor backend coverage.
+#
+# Why this suite exists:
+# - Backend selection has four precedence levels (env > project > global >
+#   default). Regressions here silently route workers to the wrong CLI.
+# - The Cursor adapter rewrites Cursor-shaped JSON into Claude-shaped JSON
+#   before delegating to careful.sh. If event paths change we want to know.
+# - dispatch.py wraps shell-quoted CLI invocations; a shell-quoting bug in
+#   the cursor branch would only surface at dispatch time.
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+UC="$ROOT/scripts/user-config.py"
+DISPATCH="$ROOT/scripts/dispatch.py"
+ADAPTER="$ROOT/scripts/hooks/careful-cursor.sh"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_cursor_backend.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+sandbox_home() { local h; h=$(new_tmp); echo "$h"; }
+make_project() {
+  local p; p=$(new_tmp)
+  (cd "$p" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init) >/dev/null
+  echo "$p"
+}
+
+# ── 1. Default backend is claude ────────────────────────────────────────
+
+echo ""
+echo "1. Default backend resolution"
+
+H=$(sandbox_home)
+T=$(make_project)
+OUT=$(HOME="$H" python3 "$UC" get mode.backend "$T")
+assert_eq "$OUT" "claude" "default mode.backend = claude"
+
+# ── 2. set + get cursor backend ─────────────────────────────────────────
+
+echo ""
+echo "2. Persist mode.backend"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" set mode.backend cursor --scope global > /dev/null
+OUT=$(HOME="$H" python3 "$UC" get mode.backend "$T")
+assert_eq "$OUT" "cursor" "global set mode.backend=cursor reads back"
+
+# Project overrides global
+HOME="$H" python3 "$UC" set mode.backend claude --scope project --project "$T" > /dev/null
+OUT=$(HOME="$H" python3 "$UC" get mode.backend "$T")
+assert_eq "$OUT" "claude" "project mode.backend overrides global"
+
+# ── 3. Invalid backend rejected at write time ───────────────────────────
+
+echo ""
+echo "3. Invalid backend rejected"
+
+H=$(sandbox_home)
+if HOME="$H" python3 "$UC" set mode.backend gemini --scope global 2>/dev/null; then
+  fail "set mode.backend=gemini should fail"
+else
+  ok "set mode.backend=gemini rejected"
+fi
+
+# ── 4. Env override (AUTONOMOUS_BACKEND) wins over config ───────────────
+
+echo ""
+echo "4. AUTONOMOUS_BACKEND env override"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" set mode.backend claude --scope global > /dev/null
+OUT=$(AUTONOMOUS_BACKEND=cursor HOME="$H" python3 "$UC" get mode.backend "$T")
+assert_eq "$OUT" "cursor" "env override flips claude → cursor"
+# Invalid env value falls through to persisted config
+OUT=$(AUTONOMOUS_BACKEND=bogus HOME="$H" python3 "$UC" get mode.backend "$T")
+assert_eq "$OUT" "claude" "invalid env value falls through to config"
+
+# ── 5. setup --backend cursor persists ──────────────────────────────────
+
+echo ""
+echo "5. setup --backend cursor"
+
+H=$(sandbox_home)
+HOME="$H" python3 "$UC" setup --scope global --backend cursor > /dev/null
+CONFIG="$H/.claude/autonomous/config.json"
+assert_file_exists "$CONFIG" "global config written"
+assert_file_contains "$CONFIG" '"backend": "cursor"' "backend persisted in JSON"
+
+# setup with invalid --backend errors out
+H=$(sandbox_home)
+if HOME="$H" python3 "$UC" setup --scope global --backend nope 2>/dev/null; then
+  fail "setup --backend=nope should fail"
+else
+  ok "setup --backend=nope rejected"
+fi
+
+# ── 6. dispatch.py picks cursor wrapper when backend=cursor ─────────────
+
+echo ""
+echo "6. dispatch.py with backend=cursor"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" set mode.backend cursor --scope global > /dev/null
+echo "test prompt" > "$T/prompt.txt"
+HOME="$H" DISPATCH_MODE=headless python3 "$DISPATCH" "$T" "$T/prompt.txt" cursortest > /dev/null 2>&1 || true
+WRAPPER="$T/.autonomous/run-cursortest.sh"
+assert_file_exists "$WRAPPER" "wrapper created with cursor backend"
+assert_file_contains "$WRAPPER" "cursor agent" "wrapper invokes 'cursor agent'"
+assert_file_contains "$WRAPPER" "\-\-force" "wrapper has --force"
+assert_file_contains "$WRAPPER" "\-\-trust" "wrapper has --trust (required for headless)"
+assert_file_not_contains "$WRAPPER" "claude --dangerously-skip-permissions" "wrapper does not invoke claude"
+pkill -f "run-cursortest.sh" 2>/dev/null || true
+
+# ── 7. dispatch.py with backend=cursor + careful=on writes .cursor/hooks.json ──
+
+echo ""
+echo "7. cursor backend + careful hook"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" set mode.backend cursor --scope global > /dev/null
+HOME="$H" python3 "$UC" set mode.careful_hook true --scope global > /dev/null
+echo "test prompt" > "$T/prompt.txt"
+HOME="$H" DISPATCH_MODE=headless python3 "$DISPATCH" "$T" "$T/prompt.txt" carefulwin > /dev/null 2>&1 || true
+HOOKS="$T/.cursor/hooks.json"
+WRAPPER="$T/.autonomous/run-carefulwin.sh"
+assert_file_exists "$HOOKS" ".cursor/hooks.json written when careful=on"
+assert_file_contains "$HOOKS" "preToolUse" "hooks.json has preToolUse event"
+assert_file_contains "$HOOKS" "beforeShellExecution" "hooks.json has beforeShellExecution event"
+assert_file_contains "$HOOKS" "careful-cursor.sh" "hooks.json points at careful-cursor.sh adapter"
+# Cursor has no --settings flag — wrapper must not invent one
+assert_file_not_contains "$WRAPPER" "\-\-settings" "wrapper does not pass --settings to cursor"
+pkill -f "run-carefulwin.sh" 2>/dev/null || true
+
+# ── 8. Unknown backend falls back to claude with warning ────────────────
+
+echo ""
+echo "8. Unknown backend fallback"
+
+H=$(sandbox_home)
+T=$(make_project)
+echo "test prompt" > "$T/prompt.txt"
+OUT=$(AUTONOMOUS_BACKEND=mistral HOME="$H" DISPATCH_MODE=headless python3 "$DISPATCH" "$T" "$T/prompt.txt" fallbackwin 2>&1 || true)
+assert_contains "$OUT" "WARNING" "stderr mentions WARNING for unknown backend"
+WRAPPER="$T/.autonomous/run-fallbackwin.sh"
+assert_file_exists "$WRAPPER" "wrapper still written (fallback to claude)"
+assert_file_contains "$WRAPPER" "claude --dangerously-skip-permissions" "fallback wrapper invokes claude"
+pkill -f "run-fallbackwin.sh" 2>/dev/null || true
+
+# ── 9. Cursor adapter: safe → allow, dangerous → deny ───────────────────
+
+echo ""
+echo "9. careful-cursor.sh adapter"
+
+OUT=$(echo '{"command":"ls -la"}' | bash "$ADAPTER")
+assert_contains "$OUT" '"permission":"allow"' "safe command → allow"
+
+OUT=$(echo '{"command":"rm -rf /"}' | bash "$ADAPTER")
+assert_contains "$OUT" '"permission": "deny"' "rm -rf / → deny"
+assert_contains "$OUT" 'filesystem root' "deny includes block reason"
+
+OUT=$(echo '{"tool_input":{"command":"git push --force origin main"}}' | bash "$ADAPTER")
+assert_contains "$OUT" '"permission": "deny"' "force-push (tool_input shape) → deny"
+
+OUT=$(echo '{"tool":{"input":{"command":"mkfs.ext4 /dev/sda1"}}}' | bash "$ADAPTER")
+assert_contains "$OUT" '"permission": "deny"' "mkfs (nested tool.input shape) → deny"
+
+# Empty / unknown event shape → allow (fail-open is intentional; matches
+# Cursor's documented behavior for hook crashes/invalid output)
+OUT=$(echo '{"unknown":"shape"}' | bash "$ADAPTER")
+assert_contains "$OUT" '"permission":"allow"' "unknown event shape → allow"
+
+OUT=$(echo 'not json at all' | bash "$ADAPTER")
+assert_contains "$OUT" '"permission":"allow"' "non-JSON input → allow"
+
+# ── 10. cursor template loads through build-sprint-prompt.py ────────────
+
+echo ""
+echo "10. cursor template renders"
+
+H=$(sandbox_home)
+T=$(make_project)
+HOME="$H" python3 "$UC" set mode.templates cursor --scope global > /dev/null
+mkdir -p "$T/.autonomous"
+HOME="$H" python3 "$ROOT/scripts/build-sprint-prompt.py" "$T" "$ROOT" "1" "test direction" "" > /dev/null
+PROMPT="$T/.autonomous/sprint-prompt.md"
+assert_file_exists "$PROMPT" "sprint-prompt rendered with cursor template"
+assert_file_contains "$PROMPT" "Sketch the smallest version" "cursor template allows present"
+assert_file_contains "$PROMPT" "shell commands that ship code" "cursor template blocks present"
+assert_file_not_contains "$PROMPT" "/office-hours" "cursor template avoids gstack-only commands"
+
+print_results


### PR DESCRIPTION
## Summary

Adds a backend abstraction so autonomous-skill workers can be dispatched via either Claude Code (default) or Cursor Agent. Selected via `mode.backend` in user-config (env > project > global, default `claude`).

- **`scripts/backends/`** — one module per CLI exposing `cli_name / is_available / install_careful_hook / build_command`. `claude.py` preserves the historic `--dangerously-skip-permissions --settings <file>` invocation. `cursor.py` invokes `cursor agent -p --force --trust --output-format text` and writes hooks at `.cursor/hooks.json` (Cursor has no per-invocation `--settings` flag).
- **`scripts/dispatch.py`** refactored to resolve backend from config and delegate wrapper construction. Unknown backend names fall back to `claude` with a stderr `WARNING:` so a typo can't silently change which CLI runs.
- **`scripts/hooks/careful-cursor.sh`** — Cursor adapter: re-shapes Cursor's preToolUse / beforeShellExecution event into a Claude-shaped Bash event and forwards to the existing `careful.sh` matcher. Probes 7 candidate JSON paths so Cursor schema variations don't bypass the guard. Returns Cursor's `{permission:"allow|deny", ...}` JSON.
- **`scripts/user-config.py`** — `mode.backend` config key with `setup --backend` flag, validation against `VALID_BACKENDS = {claude, cursor}`, `AUTONOMOUS_BACKEND` env override, and invalid-env fall-through to persisted config.
- **`schemas/autonomous-config.schema.json`** — documents `mode.backend` enum.
- **`templates/cursor/rules.json`** — backend-agnostic worker guidance (avoids gstack-only slash commands).
- **`tests/test_cursor_backend.sh` (42 tests)** + **`tests/cursor`** mock binary (mirrors `tests/claude` env-var contract).

## Hook merge behavior

Cursor's hook config lives in a single shared project file (`.cursor/hooks.json`), unlike Claude's per-invocation `settings-{window}.json`. To avoid destroying user-authored hooks:

- The backend **merges** into existing `hooks.json`. Autonomous entries are tagged with `_autonomous_managed: true` and refreshed in place; user entries (no marker) survive untouched.
- Writes are **atomic** (tmp + rename) so concurrent dispatchers can't tear the file.
- **Malformed** pre-existing files are renamed to `hooks.json.bak` before a fresh write.

## Outside-voice review notes

Independent code review (Claude subagent, since codex's gpt-5/gpt-5-codex models are gated on this account) flagged the hooks-clobber issue as high severity — fixed in commit b42ec20. Remaining notes deferred:

- **Adapter fail-open on parse failure** is intentional. Cursor's documented behavior is to allow when hooks fail (avoids blocking the user when Cursor itself ships a schema change). The catastrophic-pattern matcher in `careful.sh` still fires for any successfully-parsed shell command.
- **Concurrent dispatch in same project** is now safe (atomic write). For full parallel-sprint isolation under cursor backend, combine with `mode.worktrees=true`.
- **Three-source-of-truth duplication** (`KNOWN_BACKENDS` in dispatch.py, `VALID_BACKENDS` in user-config.py, schema enum) is a known cleanup target if a third backend is added.

## Test plan

- [x] `bash tests/test_cursor_backend.sh` (42 tests, includes merge/idempotency/recovery)
- [x] `bash tests/test_user_config.sh` (88 tests, includes `mode.backend` validation)
- [x] `bash tests/test_eval_output.sh` (34 tests — wrapper shell-quoting unchanged)
- [x] `bash tests/test_careful_hook.sh` (97 tests — claude path unchanged)
- [x] `python3 -m compileall scripts` — clean
- [ ] Live `cursor agent -p` end-to-end run (deferred — requires Cursor CLI install on reviewer's machine; mock-binary tests cover dispatch/wrapper shape)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Cursor Agent as an alternative worker backend alongside the default Claude backend.
  * Backend selection is now configurable via user settings with environment variable override capability.
  * New Cursor-specific session guidance templates for autonomous worker sessions.

* **Documentation**
  * Updated configuration documentation to include backend selection and behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->