### PR TITLE
fix(dispatch): close every tmux window opened during a sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to autonomous-skill are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- Sprint window cleanup: `evaluate-sprint.py` now closes every tmux window opened during a sprint (sprint master plus any worker windows), not just `sprint-{N}`. `dispatch.py` records each window it opens in `.autonomous/sprint-{N}-windows.txt` (sprint number derived from `conductor-state.json`, best-effort and silent if state is missing); `evaluate-sprint.py` reads the log at sprint end, kills every entry, and removes the file. Prevents leftover worker windows when a worker exits unexpectedly or the sprint master ends before `monitor-worker.py` cleans up.
+
+### Added
+- `tests/test_window_cleanup.sh` (20 tests): dispatch.py logging (write, dedup, latest sprint, no-state no-op, empty-sprints no-op), evaluate-sprint.py cleanup (kills logged + master, missing log still kills master, blank-line tolerant), eval-output regression.
+
 
 ## [0.9.0] — 2026-04-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,11 @@ Conductor (SKILL.md, user's CC session)
 - `scripts/parse-args.py` — Parse ARGS → _MAX_SPRINTS + _DIRECTION
 - `scripts/session-init.py` — Create session branch, init conductor state + backlog
 - `scripts/build-sprint-prompt.py` — Inline SPRINT.md + params → sprint-prompt.md
-- `scripts/dispatch.py` — tmux/headless session dispatch; optionally deploys careful hook when `AUTONOMOUS_WORKER_CAREFUL=1`
+- `scripts/dispatch.py` — tmux/headless session dispatch; optionally deploys careful hook when `AUTONOMOUS_WORKER_CAREFUL=1`. In tmux mode, appends each window name to `.autonomous/sprint-{N}-windows.txt` (sprint number read from conductor-state) so `evaluate-sprint.py` can close every sprint-spawned window, not just the master
 - `scripts/hooks/careful.sh` — PreToolUse Bash hook; blocks catastrophic patterns (rm -rf /, mkfs, force-push to main, DROP TABLE, fork bombs)
 - `scripts/monitor-sprint.py` — Poll for sprint-summary.json
 - `scripts/monitor-worker.py` — Poll comms.json + tmux/process liveness
-- `scripts/evaluate-sprint.py` — Read summary JSON, update conductor state
+- `scripts/evaluate-sprint.py` — Read summary JSON, update conductor state, and tear down every tmux window the sprint opened (sprint master + log entries from `sprint-{N}-windows.txt`)
 - `scripts/merge-sprint.py` — Merge or discard sprint branch
 - `scripts/worktree.py` — Per-sprint git worktree manager (opt-in via `AUTONOMOUS_SPRINT_WORKTREES=1`): creates `.worktrees/sprint-N/` with symlinked `.autonomous/`, removes on success
 - `scripts/parallel-sprint.py` — **Experimental V2.** K-parallel sprint orchestrator gated by `experimental.parallel_sprints=true` + `mode.worktrees=true`. Dispatches K workers concurrently, waits for all, merges serially (first conflict aborts the wave, preserves remaining worktrees for inspection). Max parallel capped by `experimental.max_parallel_sprints` (default 3). Not wired into SKILL.md yet — invoke manually via `parallel-sprint.py run`.
@@ -164,7 +164,7 @@ To add a new template: create `templates/<name>/rules.json` with `allows` and
 
 ## Testing
 
-785 tests across 15 suites, all pure bash:
+805 tests across 16 suites, all pure bash:
 
 ```bash
 bash tests/test_conductor.sh    # 99 tests: state management, phase transitions, exploration, stale cleanup, input validation, CLI help
@@ -182,6 +182,7 @@ bash tests/test_worktree.sh     # 65 tests: per-sprint worktree CRUD, symlink es
 bash tests/test_user_config.sh  # 88 tests: config precedence, legacy migration, malformed config, experimental flags + warnings, init command, $schema reference, schema file integrity, mode.profile (default/dev enum + validation + force-worktrees rail + env override)
 bash tests/test_parallel_sprint.sh # 27 tests: V2 parallel orchestrator — gating, validation, E2E wave dispatch + serial merge + worktree teardown, max-parallel sources
 bash tests/test_dev_mode.sh     # 19 tests: modes/dev/prompt.md content + SKILL.md Startup addendum emission (dev vs default profile, env override, AUTONOMOUS_SKILL_DIR export)
+bash tests/test_window_cleanup.sh # 20 tests: dispatch.py per-sprint window log (write/dedup/latest-sprint/missing-state/empty-sprints), evaluate-sprint.py kills logged windows + master + unlinks the log, blank-line tolerance, eval-output regression
 python3 -m compileall scripts   # quick syntax check
 ```
 

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -33,6 +33,34 @@ def tmux_available() -> bool:
     )
 
 
+def log_dispatched_window(project: Path, window: str) -> None:
+    """Append window to .autonomous/sprint-{N}-windows.txt for evaluate-sprint
+    to clean up. N is read from conductor-state.json; best-effort, never raises."""
+    state_file = project / ".autonomous" / "conductor-state.json"
+    if not state_file.exists():
+        return
+    try:
+        state = json.loads(state_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        return
+    sprints = state.get("sprints") or []
+    if not sprints:
+        return
+    sprint_num = sprints[-1].get("number")
+    if sprint_num is None:
+        return
+    log_path = project / ".autonomous" / f"sprint-{sprint_num}-windows.txt"
+    try:
+        log_path.parent.mkdir(exist_ok=True)
+        existing = log_path.read_text().splitlines() if log_path.exists() else []
+        if window in existing:
+            return
+        with log_path.open("a") as f:
+            f.write(window + "\n")
+    except OSError:
+        return
+
+
 def _careful_enabled(project_dir: Path) -> bool:
     """Honor env var first (debug override), fall through to user-config."""
     env_raw = os.environ.get("AUTONOMOUS_WORKER_CAREFUL", "")
@@ -137,6 +165,7 @@ def main(argv: list[str]) -> int:
             ["tmux", "new-window", "-n", args.window_name, f"bash {wrapper}"],
             check=False,
         )
+        log_dispatched_window(project, args.window_name)
         print("DISPATCH_MODE=tmux")
         print(f"Launched in tmux window '{args.window_name}'")
     else:

--- a/scripts/evaluate-sprint.py
+++ b/scripts/evaluate-sprint.py
@@ -17,6 +17,28 @@ def tmux_kill(window: str) -> None:
     subprocess.run(["tmux", "kill-window", "-t", window], check=False)
 
 
+def cleanup_sprint_windows(project: Path, sprint_num: str) -> None:
+    """Kill the sprint master window plus every worker window dispatch.py
+    logged for this sprint, then drop the log file."""
+    targets = [f"sprint-{sprint_num}"]
+    log_path = project / ".autonomous" / f"sprint-{sprint_num}-windows.txt"
+    if log_path.exists():
+        try:
+            for line in log_path.read_text().splitlines():
+                name = line.strip()
+                if name and name not in targets:
+                    targets.append(name)
+        except OSError:
+            pass
+    for name in targets:
+        tmux_kill(name)
+    if log_path.exists():
+        try:
+            log_path.unlink()
+        except OSError:
+            pass
+
+
 def git_log(project: Path, limit: int = 5) -> list[str]:
     result = subprocess.run(
         ["git", "log", "--oneline", f"-{limit}"],
@@ -40,7 +62,7 @@ def main(argv: list[str]) -> int:
     script_dir = Path(args.script_dir).resolve()
     summary_path = project / ".autonomous" / f"sprint-{args.sprint_num}-summary.json"
 
-    tmux_kill(f"sprint-{args.sprint_num}")
+    cleanup_sprint_windows(project, args.sprint_num)
 
     if summary_path.exists():
         data = json.loads(summary_path.read_text())

--- a/tests/test_window_cleanup.sh
+++ b/tests/test_window_cleanup.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Tests for tmux window cleanup at sprint end:
+#   - dispatch.py logs each tmux window it opens into
+#     .autonomous/sprint-{N}-windows.txt
+#   - evaluate-sprint.py reads that log, kills every listed window plus
+#     sprint-{N}, then removes the log file
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISPATCH="$SCRIPT_DIR/../scripts/dispatch.py"
+EVALUATE="$SCRIPT_DIR/../scripts/evaluate-sprint.py"
+CONDUCTOR="$SCRIPT_DIR/../scripts/conductor-state.py"
+
+# Pre-declare for set -u (eval-set vars from evaluate-sprint output)
+STATUS=""; SUMMARY=""; DIR_COMPLETE=""; PHASE=""
+
+# ── stub tmux binary ─────────────────────────────────────────────────
+# Records every invocation to $TMUX_LOG so tests can assert which
+# windows were targeted. Treats `tmux info` as success and
+# `tmux list-windows` as empty (so dispatch.py thinks tmux is up but
+# evaluate-sprint.py doesn't see real windows). Other subcommands
+# print nothing and exit 0.
+make_tmux_stub() {
+  local stub_dir="$1"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/tmux" << 'EOF'
+#!/bin/bash
+echo "$@" >> "${TMUX_LOG:-/dev/null}"
+case "$1" in
+  info) exit 0 ;;
+  list-windows) exit 0 ;;
+  new-window) exit 0 ;;
+  kill-window) exit 0 ;;
+  capture-pane) exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$stub_dir/tmux"
+}
+
+init_project() {
+  local d
+  d=$(new_tmp)
+  git -C "$d" init -q
+  git -C "$d" commit --allow-empty -m "init" -q
+  mkdir -p "$d/.autonomous"
+  python3 "$CONDUCTOR" init "$d" "test mission" "5" > /dev/null
+  echo "$d"
+}
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " test_window_cleanup.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "1. dispatch.py logs window names to sprint-N-windows.txt"
+
+T=$(init_project)
+python3 "$CONDUCTOR" sprint-start "$T" "build x" > /dev/null
+echo "test prompt" > "$T/.autonomous/p.md"
+
+STUB=$(new_tmp); make_tmux_stub "$STUB"
+TMUX_LOG="$T/tmux.log" PATH="$STUB:$PATH" \
+  python3 "$DISPATCH" "$T" "$T/.autonomous/p.md" "sprint-1" > /dev/null
+
+assert_file_exists "$T/.autonomous/sprint-1-windows.txt" \
+  "log file created on tmux dispatch"
+assert_file_contains "$T/.autonomous/sprint-1-windows.txt" "sprint-1" \
+  "log file lists sprint-1"
+
+# Add a worker entry, dispatched in the same sprint
+echo "worker prompt" > "$T/.autonomous/wp.md"
+TMUX_LOG="$T/tmux.log" PATH="$STUB:$PATH" \
+  python3 "$DISPATCH" "$T" "$T/.autonomous/wp.md" "worker" > /dev/null
+assert_file_contains "$T/.autonomous/sprint-1-windows.txt" "worker" \
+  "log file appended worker entry"
+
+LINE_COUNT=$(wc -l < "$T/.autonomous/sprint-1-windows.txt" | tr -d ' ')
+assert_eq "$LINE_COUNT" "2" "log file has exactly 2 entries (sprint-1, worker)"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "2. dispatch.py dedupes repeated window names"
+
+TMUX_LOG="$T/tmux.log" PATH="$STUB:$PATH" \
+  python3 "$DISPATCH" "$T" "$T/.autonomous/wp.md" "worker" > /dev/null
+LINE_COUNT=$(wc -l < "$T/.autonomous/sprint-1-windows.txt" | tr -d ' ')
+assert_eq "$LINE_COUNT" "2" "duplicate worker dispatch did not add a new line"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "3. dispatch.py logs against the latest sprint number"
+
+python3 "$CONDUCTOR" sprint-end "$T" "complete" "first done" > /dev/null
+python3 "$CONDUCTOR" sprint-start "$T" "build y" > /dev/null
+
+TMUX_LOG="$T/tmux.log" PATH="$STUB:$PATH" \
+  python3 "$DISPATCH" "$T" "$T/.autonomous/wp.md" "worker" > /dev/null
+assert_file_exists "$T/.autonomous/sprint-2-windows.txt" \
+  "second sprint gets its own log file"
+assert_file_contains "$T/.autonomous/sprint-2-windows.txt" "worker" \
+  "second sprint log lists worker"
+assert_file_not_contains "$T/.autonomous/sprint-1-windows.txt" "worker_two" \
+  "first sprint log untouched"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "4. dispatch.py without conductor-state.json is a no-op"
+
+T2=$(new_tmp)
+git -C "$T2" init -q
+git -C "$T2" commit --allow-empty -m "init" -q
+mkdir -p "$T2/.autonomous"
+echo "p" > "$T2/.autonomous/p.md"
+
+TMUX_LOG="$T2/tmux.log" PATH="$STUB:$PATH" \
+  python3 "$DISPATCH" "$T2" "$T2/.autonomous/p.md" "sprint-1" > /dev/null
+assert_file_not_exists "$T2/.autonomous/sprint-1-windows.txt" \
+  "no log file written without conductor-state"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "5. dispatch.py with empty sprints[] is a no-op"
+
+T3=$(init_project)
+echo "p" > "$T3/.autonomous/p.md"
+# sprint-start NOT called → sprints == []
+TMUX_LOG="$T3/tmux.log" PATH="$STUB:$PATH" \
+  python3 "$DISPATCH" "$T3" "$T3/.autonomous/p.md" "sprint-1" > /dev/null
+assert_file_not_exists "$T3/.autonomous/sprint-1-windows.txt" \
+  "no log file written with empty sprints[]"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "6. evaluate-sprint.py kills every logged window plus sprint-N"
+
+T4=$(init_project)
+python3 "$CONDUCTOR" sprint-start "$T4" "build z" > /dev/null
+cat > "$T4/.autonomous/sprint-1-summary.json" << 'EOF'
+{"status":"complete","summary":"done","commits":[],"direction_complete":true}
+EOF
+cat > "$T4/.autonomous/sprint-1-windows.txt" << 'EOF'
+sprint-1
+worker
+worker-extra
+EOF
+
+TMUX_LOG="$T4/tmux.log"
+TMUX_LOG="$TMUX_LOG" PATH="$STUB:$PATH" \
+  python3 "$EVALUATE" "$T4" "$SCRIPT_DIR/.." "1" > /dev/null
+
+KILL_COUNT=$(grep -c "^kill-window" "$TMUX_LOG" || true)
+assert_eq "$KILL_COUNT" "3" "kill-window invoked once per logged target"
+assert_file_contains "$TMUX_LOG" "kill-window -t sprint-1" "killed sprint-1"
+assert_file_contains "$TMUX_LOG" "kill-window -t worker" "killed worker"
+assert_file_contains "$TMUX_LOG" "kill-window -t worker-extra" \
+  "killed worker-extra"
+assert_file_not_exists "$T4/.autonomous/sprint-1-windows.txt" \
+  "log file deleted after cleanup"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "7. evaluate-sprint.py still kills sprint-N when log file is missing"
+
+T5=$(init_project)
+python3 "$CONDUCTOR" sprint-start "$T5" "build q" > /dev/null
+cat > "$T5/.autonomous/sprint-1-summary.json" << 'EOF'
+{"status":"complete","summary":"done","commits":[],"direction_complete":true}
+EOF
+# no sprint-1-windows.txt
+
+TMUX_LOG="$T5/tmux.log"
+TMUX_LOG="$TMUX_LOG" PATH="$STUB:$PATH" \
+  python3 "$EVALUATE" "$T5" "$SCRIPT_DIR/.." "1" > /dev/null
+
+assert_file_contains "$TMUX_LOG" "kill-window -t sprint-1" \
+  "sprint-1 killed even without log file"
+KILL_COUNT=$(grep -c "^kill-window" "$TMUX_LOG" || true)
+assert_eq "$KILL_COUNT" "1" "exactly one kill-window without log file"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "8. evaluate-sprint.py ignores blank lines in the log"
+
+T6=$(init_project)
+python3 "$CONDUCTOR" sprint-start "$T6" "build w" > /dev/null
+cat > "$T6/.autonomous/sprint-1-summary.json" << 'EOF'
+{"status":"complete","summary":"done","commits":[],"direction_complete":true}
+EOF
+printf "sprint-1\n\nworker\n\n" > "$T6/.autonomous/sprint-1-windows.txt"
+
+TMUX_LOG="$T6/tmux.log"
+TMUX_LOG="$TMUX_LOG" PATH="$STUB:$PATH" \
+  python3 "$EVALUATE" "$T6" "$SCRIPT_DIR/.." "1" > /dev/null
+
+KILL_COUNT=$(grep -c "^kill-window" "$TMUX_LOG" || true)
+assert_eq "$KILL_COUNT" "2" "blank lines skipped, only real names killed"
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "9. evaluate-sprint.py output stays eval-safe after cleanup change"
+
+T7=$(init_project)
+python3 "$CONDUCTOR" sprint-start "$T7" "build v" > /dev/null
+cat > "$T7/.autonomous/sprint-1-summary.json" << 'EOF'
+{"status":"complete","summary":"all good","commits":[],"direction_complete":true}
+EOF
+cat > "$T7/.autonomous/sprint-1-windows.txt" << 'EOF'
+sprint-1
+worker
+EOF
+
+TMUX_LOG="$T7/tmux.log"
+OUTPUT=$(TMUX_LOG="$TMUX_LOG" PATH="$STUB:$PATH" \
+  python3 "$EVALUATE" "$T7" "$SCRIPT_DIR/.." "1" 2>/dev/null)
+
+ERR_FILE=$(mktemp)
+eval "$OUTPUT" 2>"$ERR_FILE" || true
+ERR=$(cat "$ERR_FILE"); rm -f "$ERR_FILE"
+assert_eq "$ERR" "" "eval of evaluate-sprint output is clean"
+assert_eq "$STATUS" "complete" "STATUS still parsed correctly"
+
+# ═══════════════════════════════════════════════════════════════════════
+print_results


### PR DESCRIPTION
## Summary
- `dispatch.py` now appends each tmux window it opens to `.autonomous/sprint-{N}-windows.txt` (sprint number read from `conductor-state.json`, best-effort + silent if state is missing or sprints[] is empty).
- `evaluate-sprint.py` reads that log at sprint end, kills every entry plus `sprint-{N}`, then unlinks the file. Replaces the old single-target `tmux_kill(f"sprint-{N}")` call.
- Closes the gap where worker windows that escaped `monitor-worker.py`'s cleanup (worker crashed, master ended early, etc.) lingered until session teardown. `tmux kill-window` is idempotent, so this is purely additive — pre-existing per-window cleanup in `monitor-worker.py` / `monitor-sprint.py` keeps working.

## Test plan
- [x] `bash tests/test_window_cleanup.sh` — 20 new tests, all pass (log write/dedup/latest-sprint, no-state + empty-sprints no-ops, evaluate kills logged + master + unlinks, blank-line tolerance, eval-output regression)
- [x] `bash tests/test_eval_output.sh` — 34/34 (no regression)
- [x] `bash tests/test_conductor.sh` — 99/99
- [x] `bash tests/test_parallel_sprint.sh` — 27/27
- [x] `python3 -m compileall scripts` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced autonomous sprint window management: all tmux windows created during sprint execution are now systematically tracked and automatically closed at sprint completion, ensuring clean resource cleanup. The system includes robust error handling to gracefully manage edge cases such as missing state files, improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->